### PR TITLE
ARXIVNG-991 updated openapi.yaml to reflect current design

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -71,6 +71,14 @@ paths:
                 $ref: 'resources/error.json'
 
   /{upload_id}:
+    parameters:
+      -in: path
+       name: upload_id
+       description: Unique long-lived identifier for the upload.
+       required: true
+       schema:
+         type: string
+
     get:
       operationId: getUploadStatus
       summary: |
@@ -102,13 +110,7 @@ paths:
         processing and sanitization routines are performed. Existing files will
         be overwritten by files of the  same name. and any errors or warnings
         (including deleted files) will be included in the response body.
-      parameters:
-        -in: path
-         name: upload_id
-         description: Unique long-lived identifier for the upload.
-         required: true
-         schema:
-           type: string
+
       requestBody:
         content:
           application/octet-stream:
@@ -150,7 +152,7 @@ paths:
                 $ref: 'resources/error.json'
     delete:
       operationId: deleteAll
-      summary: Deletes the entire workspace.
+      description: Deletes the entire workspace.
       responses:
         '204':
           description: The workspace was deleted successfully.
@@ -160,6 +162,31 @@ paths:
           description: |
             Forbidden. Client or user is not authorized to delete this
             workspace.
+
+  /{upload_id}/delete_all:
+    summary: Delete all files in the workspace.
+    parameters:
+      -in: path
+       name: upload_id
+       description: Unique long-lived identifier for the upload.
+       required: true
+       schema:
+         type: string
+    post:
+      desription: |
+        Delete all files in the workspace. Does not delete the workspace
+        itself.
+      responses:
+        '204':
+          description: All files in the workspace were deleted successfully.
+        '401':
+          description: Unauthorized. Missing valid authentication information.
+        '403':
+          description: |
+            Forbidden. Client or user is not authorized to delete files in this
+            workspace.
+
+
 
   /{upload_id}/{file_path}:
     parameters:


### PR DESCRIPTION
Here's a pass at the OpenAPI 3 description of the file management API, based on our design discussion for the submission UI.

@DavidLFielding What do you think of the tweak to the URL pattern for things like content, lock, release, etc? I wonder whether the semantics (making the verbs sub-paths of the resource to which they apply) are a bit more RESTful?

The file refers to some JSON schemas that don't exist yet. Those can wait until further along, just wanted to put something there as a placeholder.

Two other little things:
- I described /upload as accepting a POST request with the first upload. Cuts down on the number of requests the first time?
- I wasn't sure what to do about "delete all files." Does that mean that the workspace/upload ID is also deleted? Or just that all of the files are cleared out? I wrote it as the former (DELETE request to `/upload/{upload_id}`). But it could also be a POST request to `/upload/{upload_id}/deleteAll` or something.

@eawoods Does this match your understanding of what we discussed today?