### PR TITLE
ARXIVNG-1440 changes to support upload, compilation workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 sudo: required
-cache: pip
 env:
   MIN_PYLINT_SCORE: 8
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ script:
   - pip install pipenv
   - pipenv install --dev
   - pipenv run nose2 --with-coverage
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+sudo: required
+cache: pip
+env:
+  MIN_PYLINT_SCORE: 8
+os:
+  - linux
+python:
+  - "3.6"
+script:
+  - pip install pipenv
+  - pipenv install --dev
+  - pipenv run nose2 --with-coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pipenv install
 
 ENV PATH "/opt/arxiv:${PATH}"
 
-ADD wsgi.py uwsgi.ini /opt/arxiv/
+ADD wsgi.py uwsgi.ini bootstrap.py /opt/arxiv/
 ADD filemanager/ /opt/arxiv/filemanager/
 
 # TODO: remove this when possible.

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ CMD ["uwsgi", "--http-socket", ":8000", \
      "--processes", "8", \
      "--threads", "1", \
      "--async", "100", \
+     "--wsgi-disable-file-wrapper", \
      "--ugreen", \
      "--mount", "/=wsgi.py", \
      "--logformat", "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \"%(method) %(uri) %(proto)\" %(status) %(size) %(micros) %(ttfb)"]

--- a/Pipfile
+++ b/Pipfile
@@ -17,8 +17,10 @@ jsonschema = "*"
 celery = "*"
 redis = "*"
 arxiv-auth = "==0.2.6"
+mysqlclient = "==1.4.2"
 
 [dev-packages]
+coveralls = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a610b2af3a6da84072559353ca701de7102d62e90b3abee2bc1c5d725d091cf"
+            "sha256": "66caaf1e193232e660cd00e0d2a17d239079f8aab6b1bf8ebb73fc9012452db3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -52,17 +52,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:465b4da5d292373f9ec5bb8834f26251a5f464f2ce9da1756988c16bb5e49cff",
-                "sha256:6ca40ef1893eacb37a3696bb2a5739a9b33a7d978658b451f4d87729cb5ec576"
+                "sha256:0bed0db8c10b88b3daa042adaa1fb6c3262caed39d28086e8548015405c71744",
+                "sha256:70e71e0192a68f65754ab9d2a335be3c6856a1e8a15f3bd6263ea12e2f442bc7"
             ],
-            "version": "==1.9.89"
+            "version": "==1.9.93"
         },
         "botocore": {
             "hashes": [
-                "sha256:2257dc1c012f535ef364b6b60fc9fdc822605fafd6765c3095385528669260aa",
-                "sha256:b0b9f204cbba3ad7a523f7b274e2d0ca252384e0c114fdfe94c00eb205fb2537"
+                "sha256:4df39ef9bcd7766e3a71a9e7f976ca6c9e926f451914a9c073aa50e9519436ca",
+                "sha256:d3cea95919892eac30e2ff8c5a8908022d5a93f917df3cff4ed06a6926dcc0e5"
             ],
-            "version": "==1.12.89"
+            "version": "==1.12.93"
         },
         "celery": {
             "hashes": [
@@ -290,11 +290,11 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:986a7f97808a865405c5fd98fae5ebfa963c31520a56c783df159e9a81e41b3e",
-                "sha256:cc5df73cc11d35655a8c364f45d07b13c8db82c000def4bd7721be13356533b4"
+                "sha256:308c274eb8482fbf16006f549137ddc0d69e5a589465e37b99c4564414363ca7",
+                "sha256:e80fd6af34614a0e898a57f14296d0dacb584648f0339c2e000ddbf0f4cc2f8d"
             ],
             "index": "pypi",
-            "version": "==0.660"
+            "version": "==0.670"
         },
         "mypy-extensions": {
             "hashes": [
@@ -305,11 +305,10 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:6883a4dd98903bad375c859ead1a480e1245ea3a8d9b038ea2c091c1865ba673",
-                "sha256:a62220410e26ce2d2ff94dd0138c3ecfb91db634464a9afb4c8e6b50f0a67e00",
-                "sha256:e1b9f3a8928ddb4985ca3e3c9f2aa81b19e831bbf6fabf5681ee356738dbbbb2"
+                "sha256:b95edaa41d6cc47deecabcdcbb5ab437ad9ae6d8955f5cf10d1847b37e66ef5e"
             ],
-            "version": "==1.4.1"
+            "index": "pypi",
+            "version": "==1.4.2"
         },
         "nose2": {
             "hashes": [
@@ -346,6 +345,7 @@
                 "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
                 "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==2.8.0"
         },
         "pytz": {
@@ -399,44 +399,42 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:023625bfa9359e29bd6e24cac2a4503495b49761d48a5f1e38333fc4ac4d93fe",
-                "sha256:07591f7a5fdff50e2e566c4c1e9df545c75d21e27d98d18cb405727ed0ef329c",
-                "sha256:153e526b0f4ffbfada72d0bb5ffe8574ba02803d2f3a9c605c8cf99dfedd72a2",
-                "sha256:3ad2bdcd46a4a1518d7376e9f5016d17718a9ed3c6a3f09203d832f6c165de4a",
-                "sha256:3ea98c84df53ada97ee1c5159bb3bc784bd734231235a1ede14c8ae0775049f7",
-                "sha256:51a7141ccd076fa561af107cfb7a8b6d06a008d92451a1ac7e73149d18e9a827",
-                "sha256:52c93cd10e6c24e7ac97e8615da9f224fd75c61770515cb323316c30830ddb33",
-                "sha256:6344c84baeda3d7b33e157f0b292e4dd53d05ddb57a63f738178c01cac4635c9",
-                "sha256:64699ca1b3bd5070bdeb043e6d43bc1d0cebe08008548f4a6bee782b0ecce032",
-                "sha256:74903f2e56bbffe29282ef8a5487d207d10be0f8513b41aff787d954a4cf91c9",
-                "sha256:7891710dba83c29ee2bd51ecaa82f60f6bede40271af781110c08be134207bf2",
-                "sha256:91976c56224e26c256a0de0f76d2004ab885a29423737684b4f7ebdd2f46dde2",
-                "sha256:9bad678a576ecc71f25eba9f1e3fd8d01c28c12a2834850b458428b3e855f062",
-                "sha256:b4726339a4c180a8b6ad9d8b50d2b6dc247e1b79b38fe2290549c98e82e4fd15",
-                "sha256:ba36f6aa3f8933edf94ea35826daf92cbb3ec248b89eccdc053d4a815d285357",
-                "sha256:bbc96bde544fd19e9ef168e4dfa5c3dfe704bfa78128fa76f361d64d6b0f731a",
-                "sha256:c0c927f1e44469056f7f2dada266c79b577da378bbde3f6d2ada726d131e4824",
-                "sha256:c0f9a3708008aa59f560fa1bd22385e05b79b8e38e0721a15a8402b089243442",
-                "sha256:f0bf6f36ff9c5643004171f11d2fdc745aa3953c5aacf2536a0685db9ceb3fb1",
-                "sha256:f5be39a0146be663cbf210a4d95c3c58b2d7df7b043c9047c5448e358f0550a2",
-                "sha256:fcd198bf19d9213e5cbf2cde2b9ef20a9856e716f76f9476157f90ae6de06cc6"
+                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
+                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
+                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
+                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
+                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
+                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
+                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
+                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
+                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
+                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
+                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
+                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
+                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
+                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
+                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
+                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
+                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
+                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
+                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
-            "version": "==1.2.0"
+            "version": "==1.3.1"
         },
         "urllib3": {
             "hashes": [
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.24.1"
         },
         "uwsgi": {
             "hashes": [
-                "sha256:d2318235c74665a60021a4fc7770e9c2756f9fc07de7b8c22805efe85b5ab277"
+                "sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583"
             ],
             "index": "pypi",
-            "version": "==2.0.17.1"
+            "version": "==2.0.18"
         },
         "vine": {
             "hashes": [
@@ -459,5 +457,103 @@
             "version": "==1.11.1"
         }
     },
-    "develop": {}
+    "develop": {
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:06123b58a1410873e22134ca2d88bd36680479fe354955b3579fb8ff150e4d27",
+                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
+                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
+                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
+                "sha256:0d34245f824cc3140150ab7848d08b7e2ba67ada959d77619c986f2062e1f0e8",
+                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
+                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
+                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
+                "sha256:258b21c5cafb0c3768861a6df3ab0cfb4d8b495eee5ec660e16f928bf7385390",
+                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
+                "sha256:3ad59c84c502cd134b0088ca9038d100e8fb5081bbd5ccca4863f3804d81f61d",
+                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
+                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
+                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
+                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
+                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
+                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
+                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
+                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
+                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
+                "sha256:71afc1f5cd72ab97330126b566bbf4e8661aab7449f08895d21a5d08c6b051ff",
+                "sha256:7349c27128334f787ae63ab49d90bf6d47c7288c63a0a5dfaa319d4b4541dd2c",
+                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
+                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
+                "sha256:859714036274a75e6e57c7bab0c47a4602d2a8cfaaa33bbdb68c8359b2ed4f5c",
+                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
+                "sha256:869ef4a19f6e4c6987e18b315721b8b971f7048e6eaea29c066854242b4e98d9",
+                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
+                "sha256:977e2d9a646773cc7428cdd9a34b069d6ee254fadfb4d09b3f430e95472f3cf3",
+                "sha256:99bd767c49c775b79fdcd2eabff405f1063d9d959039c0bdd720527a7738748a",
+                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
+                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
+                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
+                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
+                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
+                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
+                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
+                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
+                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
+                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
+                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+            ],
+            "version": "==4.5.2"
+        },
+        "coveralls": {
+            "hashes": [
+                "sha256:ab638e88d38916a6cedbf80a9cd8992d5fa55c77ab755e262e00b36792b7cd6d",
+                "sha256:b2388747e2529fa4c669fb1e3e2756e4e07b6ee56c7d9fce05f35ccccc913aa0"
+            ],
+            "index": "pypi",
+            "version": "==1.5.1"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "markers": "python_version >= '3.4'",
+            "version": "==1.24.1"
+        }
+    }
 }

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,27 @@
+"""Bootstrap the file manager service."""
+
+import time
+from arxiv.base import logging
+from filemanager.factory import create_web_app
+from filemanager.services import uploads
+
+logger = logging.getLogger(__name__)
+
+
+if __name__ == '__main__':
+    app = create_web_app()
+    with app.app_context():
+        session = uploads.db.session
+        wait = 2
+        while True:
+            try:
+                session.execute('SELECT 1')
+                break
+            except Exception as e:
+                logger.info(e)
+                logger.info(f'...waiting {wait} seconds...')
+                time.sleep(wait)
+                wait *= 2
+        logger.info('Initializing database')
+        uploads.db.create_all()
+        exit(0)

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -28,7 +28,7 @@ from filemanager.shared import url_for
 
 from filemanager.domain import Upload
 from filemanager.services import uploads
-
+from filemanager.process.upload import Upload as UploadWorkspace
 from filemanager.arxiv.file import File
 
 # Temporary logging at service level - just to get something in place to build on
@@ -177,7 +177,7 @@ def delete_workspace(upload_id: int) -> Response:
                             "current state is '%s'", upload_id, upload_db_data.state)
                 raise NotFound(UPLOAD_WORKSPACE_NOT_FOUND)
 
-            upload_workspace = filemanager.process.upload.Upload(upload_id)
+            upload_workspace = UploadWorkspace(upload_id)
 
             # Call routine that will do the actual work
             upload_workspace.remove_workspace()
@@ -251,14 +251,14 @@ def client_delete_file(upload_id: str, public_file_path: str) -> Response:
         else:
 
             # Create Upload object
-            upload_workspace = filemanager.process.upload.Upload(upload_id)
+            upload_workspace = UploadWorkspace(upload_id)
 
             # Call routine that will do the actual work
             upload_workspace.client_remove_file(public_file_path)
 
-
     except IOError:
-        logger.error("%s: Delete file request failed ", upload_db_data.upload_id)
+        logger.error("%s: Delete file request failed ",
+                     upload_db_data.upload_id)
         raise InternalServerError(CANT_DELETE_FILE)
     except NotFound as nf:
         logger.info("%s: DeleteFile: %s", upload_id, nf)
@@ -276,12 +276,12 @@ def client_delete_file(upload_id: str, public_file_path: str) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    response_data = {
+    response_data = _status_data(upload_db_data, upload_workspace)
+    response_data.update({
         'reason': UPLOAD_DELETED_FILE,
         'checksum': upload_workspace.content_checksum()
-    }  # Get rid of pylint error
-    status_code = status.HTTP_204_NO_CONTENT
-    return response_data, status_code, {}
+    })  # Get rid of pylint errorT
+    return response_data, status.HTTP_200_OK, {}
 
 
 def client_delete_all_files(upload_id: str) -> Response:
@@ -324,7 +324,7 @@ def client_delete_all_files(upload_id: str) -> Response:
         else:
 
             # Create Upload object
-            upload_workspace = filemanager.process.upload.Upload(upload_id)
+            upload_workspace = UploadWorkspace(upload_id)
 
             upload_workspace.client_remove_all_files()
 
@@ -343,12 +343,12 @@ def client_delete_all_files(upload_id: str) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    response_data = {
+    response_data = _status_data(upload_db_data, upload_workspace)
+    response_data.update({
         'reason': UPLOAD_DELETED_ALL_FILES,
         'checksum': upload_workspace.content_checksum()
-    }  # Get rid of pylint error
-    status_code = status.HTTP_204_NO_CONTENT
-    return response_data, status_code, {}
+    })  # Get rid of pylint error
+    return response_data, status.HTTP_200_OK, {}
 
 
 def upload(upload_id: Optional[int], file: FileStorage, archive: str,
@@ -479,7 +479,7 @@ def upload(upload_id: Optional[int], file: FileStorage, archive: str,
             start_datetime = datetime.now(UTC)
 
             # Create Upload object
-            upload_workspace = filemanager.process.upload.Upload(upload_id)
+            upload_workspace = UploadWorkspace(upload_id)
 
             # Process upload_db_data
             upload_workspace.process_upload(file, ancillary=ancillary)
@@ -537,22 +537,9 @@ def upload(upload_id: Optional[int], file: FileStorage, archive: str,
 
             status_code = status.HTTP_201_CREATED
 
-            response_data = {
-                'upload_id': upload_db_data.upload_id,
-                'upload_total_size': upload_workspace.total_upload_size,
-                'created_datetime': upload_db_data.created_datetime,
-                'modified_datetime': upload_db_data.modified_datetime,
-                'start_datetime': upload_db_data.lastupload_start_datetime,
-                'completion_datetime': upload_db_data.lastupload_completion_datetime,
-                'files': json.loads(upload_db_data.lastupload_file_summary),
-                'errors': json.loads(upload_db_data.lastupload_logs),
-                'upload_status': upload_db_data.lastupload_upload_status,
-                'workspace_state': upload_db_data.state,
-                'lock_state': upload_db_data.lock,
-                'source_format': upload_workspace.source_format,
-                'checksum': upload_workspace.content_checksum()
-            }
-            logger.info("%s: Generating upload summary.", upload_db_data.upload_id)
+            response_data = _status_data(upload_db_data, upload_workspace)
+            logger.info("%s: Generating upload summary.",
+                        upload_db_data.upload_id)
             return response_data, status_code, headers
 
     except IOError as e:
@@ -613,7 +600,7 @@ def upload_summary(upload_id: int) -> Response:
             logger.info("%s: Upload summary request.", upload_db_data.upload_id)
 
             # Create Upload object
-            upload_workspace = filemanager.process.upload.Upload(upload_id)
+            upload_workspace = UploadWorkspace(upload_id)
             file_list = upload_workspace.create_file_list()
 
             details_list = []
@@ -629,22 +616,10 @@ def upload_summary(upload_id: int) -> Response:
                     details_list.append(file_details)
 
             status_code = status.HTTP_200_OK
-            response_data = {
-                'upload_id': upload_db_data.upload_id,
-                'upload_total_size': upload_workspace.total_upload_size,
-                'created_datetime': upload_db_data.created_datetime,
-                'modified_datetime': upload_db_data.modified_datetime,
-                'start_datetime': upload_db_data.lastupload_start_datetime,
-                'completion_datetime': upload_db_data.lastupload_completion_datetime,
-                'files': details_list,
-                'errors': [],
-                'upload_status': upload_db_data.lastupload_upload_status,
-                'workspace_state': upload_db_data.state,
-                'lock_state': upload_db_data.lock,
-                'source_format': upload_workspace.source_format,
-                'checksum': upload_workspace.content_checksum()
-            }
-            logger.info("%s: Upload summary request.", upload_db_data.upload_id)
+            response_data = _status_data(upload_db_data, upload_workspace)
+            response_data.update({'files': details_list, 'errors': []})
+            logger.info("%s: Upload summary request.",
+                        upload_db_data.upload_id)
 
     except IOError:
         # response_data = ERROR_RETRIEVING_UPLOAD
@@ -968,7 +943,7 @@ def check_upload_content_exists(upload_id: int) -> Response:
         raise NotFound(UPLOAD_NOT_FOUND)
 
     logger.info("%s: Upload content summary request.", upload_id)
-    upload_workspace = filemanager.process.upload.Upload(upload_id)
+    upload_workspace = UploadWorkspace(upload_id)
 
     # This will potentially build content package if it does not exist
     checksum = upload_workspace.content_checksum()
@@ -1010,7 +985,7 @@ def get_upload_content(upload_id: int) -> Response:
 
     if upload_db_data is None:
         raise NotFound(UPLOAD_NOT_FOUND)
-    upload_workspace = filemanager.process.upload.Upload(upload_id)
+    upload_workspace = UploadWorkspace(upload_id)
     checksum = upload_workspace.content_checksum()
     filepointer = upload_workspace.get_content()
     headers = {
@@ -1050,7 +1025,7 @@ def check_upload_file_content_exists(upload_id: int, public_file_path: str) -> R
 
     try:
 
-        upload_workspace = filemanager.process.upload.Upload(upload_id)
+        upload_workspace = UploadWorkspace(upload_id)
 
         # file exists
         if upload_workspace.content_file_exists(public_file_path):
@@ -1119,7 +1094,7 @@ def get_upload_file_content(upload_id: int, public_file_path: str) -> Response:
 
     try:
 
-        upload_workspace = filemanager.process.upload.Upload(upload_id)
+        upload_workspace = UploadWorkspace(upload_id)
 
         # Returns path if file exists
         if upload_workspace.content_file_exists(public_file_path):
@@ -1189,7 +1164,7 @@ def check_upload_source_log_exists(upload_id: int) -> Response:
         raise NotFound(UPLOAD_NOT_FOUND)
 
     logger.info("%s: Test for source log.", upload_id)
-    upload_workspace = filemanager.process.upload.Upload(upload_id)
+    upload_workspace = UploadWorkspace(upload_id)
 
     checksum = upload_workspace.source_log_checksum
     size = upload_workspace.source_log_size
@@ -1226,7 +1201,7 @@ def get_upload_source_log(upload_id: int) -> Response:
     if upload_db_data is None:
         raise NotFound(UPLOAD_NOT_FOUND)
 
-    upload_workspace = filemanager.process.upload.Upload(upload_id)
+    upload_workspace = UploadWorkspace(upload_id)
 
     checksum = upload_workspace.source_log_checksum
     size = upload_workspace.source_log_size
@@ -1274,6 +1249,7 @@ def __last_modified(filepath: str) -> str:
     Last modified date string for specified file.
     """
     return datetime.utcfromtimestamp(os.path.getmtime(filepath))
+
 
 def __content_pointer(service_log_path : str) -> io.BytesIO:
     """Get a file-pointer for service log.
@@ -1345,3 +1321,22 @@ def get_upload_service_log() -> Response:
         'Last-Modified': modified
     }
     return filepointer, status.HTTP_200_OK, headers
+
+
+def _status_data(upload_db_data: Upload,
+                 upload_workspace: UploadWorkspace) -> dict:
+    return {
+        'upload_id': upload_db_data.upload_id,
+        'upload_total_size': upload_workspace.total_upload_size,
+        'created_datetime': upload_db_data.created_datetime,
+        'modified_datetime': upload_db_data.modified_datetime,
+        'start_datetime': upload_db_data.lastupload_start_datetime,
+        'completion_datetime': upload_db_data.lastupload_completion_datetime,
+        'files': json.loads(upload_db_data.lastupload_file_summary),
+        'errors': json.loads(upload_db_data.lastupload_logs),
+        'upload_status': upload_db_data.lastupload_upload_status,
+        'workspace_state': upload_db_data.state,
+        'lock_state': upload_db_data.lock,
+        'source_format': upload_workspace.source_format,
+        'checksum': upload_workspace.content_checksum()
+    }

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -61,10 +61,10 @@ file_handler = logging.FileHandler(service_log_path, 'a')
 datefmt = '%d/%b/%Y:%H:%M:%S %z'  # Used to format asctime.
 formatter = logging.Formatter('%(asctime)s %(message)s', '%d/%b/%Y:%H:%M:%S %z')
 file_handler.setFormatter(formatter)
-logger.handlers = []
+# logger.handlers = []
 logger.addHandler(file_handler)
 logger.setLevel(logging.DEBUG)
-logger.propagate = False
+logger.propagate = True
 
 # End logging configuration
 
@@ -396,6 +396,7 @@ def upload(upload_id: Optional[int], file: FileStorage, archive: str,
 
     # File argument is required to exist and have a name associated with it.
     # It is standard practice that if user fails to select file the filename is null.
+    logger.debug(f'Handling upload request for {upload_id}')
     if file is None:
         # Crash and burn...not quite...do we need info about client?
         logger.error(f'Upload request is missing file/archive payload.')
@@ -420,10 +421,11 @@ def upload(upload_id: Optional[int], file: FileStorage, archive: str,
 
     # If this is a new upload then we need to create a workspace and add to database.
     if upload_id is None:
+        logger.debug('This is a new upload workspace.')
         try:
             logger.info("Create new workspace: Upload request: "
                         "file='%s' archive='%s'", file.filename, archive)
-            user_id = user.user_id
+            user_id = str(user.user_id)
 
             if archive is None:
                 arch = ''

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -1295,7 +1295,7 @@ class Upload:
             new_file_obj = File(new_filepath, os.path.dirname(new_filepath))
 
             # Check if file was changed
-            is_same = filecmp.cmp(filepath, new_filepath)
+            is_same = filecmp.cmp(filepath, new_filepath, shallow=False)
 
             if is_same:
                 os.remove(new_filepath)

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -1617,6 +1617,8 @@ class Upload:
 
     def pack_content(self) -> str:
         """Pack the entire source directory into a tarball."""
+        if os.path.exists(self.get_content_path()):
+            os.unlink(self.get_content_path())
         with tarfile.open(self.get_content_path(), "w:gz") as tar:
             tar.add(self.get_source_directory(), arcname=os.path.sep)
         return self.get_content_path()
@@ -1631,7 +1633,7 @@ class Upload:
 
     def get_content(self) -> io.BytesIO:
         """Get a file-pointer for the packed content tarball."""
-        if not os.path.exists(self.get_content_path()):
+        if self.content_package_stale or not self.content_package_exists:
             self.pack_content()
         return open(self.get_content_path(), 'rb')
 
@@ -1668,17 +1670,20 @@ class Upload:
         """
         Return b64-encoded MD5 hash of the packed content tarball.
 
-        Triggers building content package when pre-existing package is not found or stale
-        relative to source files.
+        Triggers building content package when pre-existing package is not
+        found or stale relative to source files.
         """
         if not self.content_package_exists or self.content_package_stale:
             self.pack_content()
+        return self._get_checksum(self.get_content_path())
 
+    def _get_checksum(self, path: str) -> str:
         hash_md5 = md5()
-        with open(self.get_content_path(), "rb") as f:
+        with open(path, "rb") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 hash_md5.update(chunk)
         return urlsafe_b64encode(hash_md5.digest()).decode('utf-8')
+
 
     # Content file routines
 
@@ -1914,7 +1919,7 @@ class Upload:
         # Calculate number of files in submission source (excludes ancillary files)
         format_list['files'] = format_list['all_files'] - format_list['ancillary']
 
-        self.log(f"All Files: {format_list['all_files']} files: " 
+        self.log(f"All Files: {format_list['all_files']} files: "
                  f"{format_list['files']} ancillary: {format_list['ancillary']}")
 
         return format_list

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -1633,7 +1633,8 @@ class Upload:
 
     def get_content(self) -> io.BytesIO:
         """Get a file-pointer for the packed content tarball."""
-        if self.content_package_stale or not self.content_package_exists:
+        if not self.content_package_exists or \
+                (self.content_package_exists and self.content_package_stale):
             self.pack_content()
         return open(self.get_content_path(), 'rb')
 

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -28,7 +28,8 @@ def is_owner(session: auth_domain.Session, upload_id: str, **kwargs) -> bool:
     if upload_obj is None:
         return True
 
-    return session.user.user_id == uploads.retrieve(upload_id).owner_user_id
+    return str(session.user.user_id) \
+        == str(uploads.retrieve(upload_id).owner_user_id)
 
 
 @blueprint.route('/status', methods=['GET'])

--- a/generate_token.py
+++ b/generate_token.py
@@ -57,9 +57,7 @@ def generate_token(user_id: str, email: str, username: str,
                 affiliation=affiliation,
                 rank=int(rank),
                 country=country,
-                default_category=domain.Category(
-                    *default_category.split('.', 1)
-                ),
+                default_category=domain.Category(default_category),
                 submission_groups=submission_groups.split(',')
             )
         ),

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -200,8 +200,12 @@ paths:
         Delete all files in the workspace. Does not delete the workspace
         itself.
       responses:
-        '204':
+        '200':
           description: All files in the workspace were deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: 'resources/Result.json'
         '401':
           description: Unauthorized. Missing valid authentication information.
         '403':
@@ -228,8 +232,12 @@ paths:
       operationId: deleteFile
       summary: Deletes a single file.
       responses:
-        '204':
+        '200':
           description: The file was deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: 'resources/Result.json'
         '401':
           description: Unauthorized. Missing valid authentication information.
         '403':

--- a/schema/resources/uploadCreate.json
+++ b/schema/resources/uploadCreate.json
@@ -5,6 +5,10 @@
   "required": ["upload_id", "create_datetime"],
   "type": "object",
   "properties": {
+    "checksum": {
+      "description": "Base64-encoded MD5 hash of the source package.",
+      "type": "string"
+    },
     "upload_id": {
       "description": "Short-lived task identifier for the upload.",
       "type": "integer"

--- a/schema/resources/uploadResult.json
+++ b/schema/resources/uploadResult.json
@@ -12,6 +12,10 @@
   ],
   "type": "object",
   "properties": {
+    "checksum": {
+      "description": "Base64-encoded MD5 hash of the source package.",
+      "type": "string"
+    },
     "upload_id": {
       "description": "Unique long-lived identifier for the upload processing result.",
       "type": "integer"

--- a/tests/test_process_upload.py
+++ b/tests/test_process_upload.py
@@ -315,6 +315,10 @@ class TestInternalSupportRoutines(TestCase):
         # Check that file generated is what we expected
         self.assertTrue(has_cr(tfilename))
         self.assertFalse(has_cr(destfilename))
+        reference = os.path.join(TEST_FILES_DIRECTORY, 'AfterUnPCify.eps')
+        is_same = filecmp.cmp(destfilename, reference, shallow=False)
+        self.assertTrue(is_same,
+                        'Eliminated unwanted CR characters from DOS file.')
 
         # UnMACify
 
@@ -328,6 +332,10 @@ class TestInternalSupportRoutines(TestCase):
         # Check that file generated is what we expected
         self.assertTrue(has_cr(tfilename))
         self.assertFalse(has_cr(destfilename))
+        reference = os.path.join(TEST_FILES_DIRECTORY, 'AfterUnMACify.eps')
+        is_same = filecmp.cmp(destfilename, reference, shallow=False)
+        self.assertTrue(is_same,
+                        'Eliminated unwanted CR characters from MAC file.')
 
         # cleanup workspace
         upload.remove_workspace()

--- a/tests/test_process_upload.py
+++ b/tests/test_process_upload.py
@@ -1,6 +1,7 @@
 """Tests for :mod:`zero.process.upload`."""
 
 from unittest import TestCase
+import re
 from datetime import datetime
 # from filemanager.domain import Upload
 from filemanager.process import upload
@@ -290,6 +291,12 @@ class TestInternalSupportRoutines(TestCase):
         Test the filtering of unwanted CR characters from specified file.
         :return:
         """
+        def has_cr(path):
+            with open(path, 'rb') as f:
+                for line in f:
+                    if re.search(b'\r\n?', line) is not None:
+                        return True
+            return False
 
         # Copy the files that will be modified to temporary location
         tmp_dir = tempfile.mkdtemp()
@@ -306,9 +313,8 @@ class TestInternalSupportRoutines(TestCase):
         upload.unmacify(file_obj)
 
         # Check that file generated is what we expected
-        reference = os.path.join(TEST_FILES_DIRECTORY, 'AfterUnPCify.eps')
-        is_same = filecmp.cmp(destfilename, reference, shallow=False)
-        self.assertTrue(is_same, 'Eliminated unwanted CR characters from DOS file.')
+        self.assertTrue(has_cr(tfilename))
+        self.assertFalse(has_cr(destfilename))
 
         # UnMACify
 
@@ -320,9 +326,8 @@ class TestInternalSupportRoutines(TestCase):
         upload.unmacify(file_obj)
 
         # Check that file generated is what we expected
-        reference = os.path.join(TEST_FILES_DIRECTORY, 'AfterUnMACify.eps')
-        is_same = filecmp.cmp(destfilename, reference, shallow=False)
-        self.assertTrue(is_same, 'Eliminated unwanted CR characters from MAC file.')
+        self.assertTrue(has_cr(tfilename))
+        self.assertFalse(has_cr(destfilename))
 
         # cleanup workspace
         upload.remove_workspace()

--- a/tests/test_process_upload.py
+++ b/tests/test_process_upload.py
@@ -307,7 +307,7 @@ class TestInternalSupportRoutines(TestCase):
 
         # Check that file generated is what we expected
         reference = os.path.join(TEST_FILES_DIRECTORY, 'AfterUnPCify.eps')
-        is_same = filecmp.cmp(destfilename, reference)
+        is_same = filecmp.cmp(destfilename, reference, shallow=False)
         self.assertTrue(is_same, 'Eliminated unwanted CR characters from DOS file.')
 
         # UnMACify
@@ -321,7 +321,7 @@ class TestInternalSupportRoutines(TestCase):
 
         # Check that file generated is what we expected
         reference = os.path.join(TEST_FILES_DIRECTORY, 'AfterUnMACify.eps')
-        is_same = filecmp.cmp(destfilename, reference)
+        is_same = filecmp.cmp(destfilename, reference, shallow=False)
         self.assertTrue(is_same, 'Eliminated unwanted CR characters from MAC file.')
 
         # cleanup workspace

--- a/tests/test_routes_upload_api.py
+++ b/tests/test_routes_upload_api.py
@@ -54,9 +54,7 @@ def generate_token(app: Flask, scope: List[str]) -> str:
                 affiliation=affiliation,
                 rank=int(rank),
                 country=country,
-                default_category=domain.Category(
-                    *default_category.split('.', 1)
-                ),
+                default_category=domain.Category(default_category),
                 submission_groups=submission_groups.split(',')
             )
         ),
@@ -598,7 +596,7 @@ class TestUploadAPIRoutes(TestCase):
         response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
                                       headers={'Authorization': token})
         print(f"Delete File Response:'{public_file_path}'\n" + str(response.data) + '\n')
-        self.assertEqual(response.status_code, 204,
+        self.assertEqual(response.status_code, 200,
                          "Delete an individual file: '{public_file_path}'.")
 
         # expected_data = {'reason': 'deleted file'}
@@ -654,7 +652,7 @@ class TestUploadAPIRoutes(TestCase):
         response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
                                       headers={'Authorization': token})
         print(f"Delete file in subdirectory anc Response:'{public_file_path}'\n" + str(response.data) + '\n')
-        self.assertEqual(response.status_code, 204,
+        self.assertEqual(response.status_code, 200,
                          f"Delete file in subdirectory: '{public_file_path}'.")
 
         # Try to delete file in subdirectory - valid file deletion
@@ -663,7 +661,7 @@ class TestUploadAPIRoutes(TestCase):
         response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
                                       headers={'Authorization': token})
         print(f"Delete file in subdirectory anc Response:'{public_file_path}'\n" + str(response.data) + '\n')
-        self.assertEqual(response.status_code, 204,
+        self.assertEqual(response.status_code, 200,
                          f"Delete file in subdirectory: '{public_file_path}'.")
 
         # Try an delete file a second time...we'll know if first delete really worked.
@@ -762,7 +760,7 @@ class TestUploadAPIRoutes(TestCase):
                                     headers={'Authorization': token},
                                     content_type='multipart/form-data')
 
-        self.assertEqual(response.status_code, 204, "Delete all user-uploaded files.")
+        self.assertEqual(response.status_code, 200, "Delete all user-uploaded files.")
 
         # There are really not many exceptions we can generate as long as the upload workspace
         # exists. If upload workspace exists this command will remove all files and directories
@@ -992,7 +990,7 @@ class TestUploadAPIRoutes(TestCase):
                                     headers={'Authorization': token},
                                     content_type='multipart/form-data')
 
-        self.assertEqual(response.status_code, 204, "Delete all user-uploaded "
+        self.assertEqual(response.status_code, 200, "Delete all user-uploaded "
                                                     "files from locked workspace.")
 
         # Clean up after ourselves
@@ -1115,7 +1113,7 @@ class TestUploadAPIRoutes(TestCase):
                                     headers={'Authorization': token},
                                     content_type='multipart/form-data')
 
-        self.assertEqual(response.status_code, 204, "Delete all user-uploaded "
+        self.assertEqual(response.status_code, 200, "Delete all user-uploaded "
                                                     "files from released workspace.")
 
         # Clean up after ourselves
@@ -1408,7 +1406,7 @@ class TestUploadAPIRoutes(TestCase):
 
         upload_data: Dict[str, Any] = json.loads(response.data)
 
-        amsg = ("Status returned to 'READY'." 
+        amsg = ("Status returned to 'READY'."
                 " Removed file causing fatal error."
                 f" (ID:{upload_data['upload_id']})")
         self.assertEqual(upload_data['upload_status'], "READY", amsg)
@@ -1608,7 +1606,7 @@ class TestUploadAPIRoutes(TestCase):
         response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
                                       headers={'Authorization': token})
 
-        self.assertEqual(response.status_code, 204, "Delete an individual file.")
+        self.assertEqual(response.status_code, 200, "Delete an individual file.")
 
         # Delete another file
         public_file_path = "lipics-v2016.cls"
@@ -1617,7 +1615,7 @@ class TestUploadAPIRoutes(TestCase):
         # response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{encoded_file_path}",
         response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
                                       headers={'Authorization': token})
-        self.assertEqual(response.status_code, 204, "Delete an individual file.")
+        self.assertEqual(response.status_code, 200, "Delete an individual file.")
 
         # Get summary after deletions
         response = self.client.get(f"/filemanager/api/{upload_data['upload_id']}",
@@ -1668,7 +1666,7 @@ class TestUploadAPIRoutes(TestCase):
                                     headers={'Authorization': token},
                                     content_type='multipart/form-data')
 
-        self.assertEqual(response.status_code, 204, "Delete all user-uploaded files.")
+        self.assertEqual(response.status_code, 200, "Delete all user-uploaded files.")
 
         # Finally, after deleting all files, check the total upload size
 

--- a/tests/test_unit_file.py
+++ b/tests/test_unit_file.py
@@ -33,7 +33,7 @@ class TestFileClass(TestCase):
 
         # TODO implement sha256sum function
         self.assertEquals(file.sha256sum, "NOT IMPLEMENTED YET", "Check sha256sum method()")
-        self.assertEquals(file.checksum, "8KwlZuQvByH23+4HIcANGQ==", "Generate checksum (MD5)")
+        self.assertEquals(file.checksum, "8KwlZuQvByH23-4HIcANGQ==", "Generate checksum (MD5)")
         file.description = 'This is my favorite photo.'
         self.assertEquals(file.description, 'This is my favorite photo.', "Check description() method")
         self.assertEquals(file.is_tex_type, False, "Check is_tex_type() method")


### PR DESCRIPTION
In order to keep the submission consistent, it's nice to get status information back after deletion actions. So this change basically returns ``200`` after deletion along with the workspace status, instead of ``204``. Everything else is just tweaks for clarity, minor consolidation.

I am still getting one failing test, and I can't figure out why it would be related to these changes:

```
======================================================================
FAIL: test_check_file_unmacify (tests.test_process_upload.TestInternalSupportRoutines)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/brp53/projects/arxiv-filemanager/tests/test_process_upload.py", line 325, in test_check_file_unmacify
    self.assertTrue(is_same, 'Eliminated unwanted CR characters from MAC file.')
AssertionError: False is not true : Eliminated unwanted CR characters from MAC file.

----------------------------------------------------------------------
```