### PR TITLE
updated dependencies, minor bugfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ CMD ["uwsgi", "--http-socket", ":8000", \
      "-M", \
      "-t 3000", \
      "--manage-script-name", \
-     "--processes", "8", \
+     "--processes", "1", \
      "--threads", "1", \
-     "--async", "100", \
+     "--async", "0", \
+     "--queue", "0", \
      "--wsgi-disable-file-wrapper", \
-     "--ugreen", \
      "--mount", "/=wsgi.py", \
      "--logformat", "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \"%(method) %(uri) %(proto)\" %(status) %(size) %(micros) %(ttfb)"]

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-arxiv-base = "==0.12.1"
+arxiv-base = "==0.15.3rc1"
 flask = "*"
 "nose2" = "*"
 flask-sqlalchemy = "*"
@@ -16,7 +16,7 @@ pyjwt = "*"
 jsonschema = "*"
 celery = "*"
 redis = "*"
-arxiv-auth = "==0.2.6"
+arxiv-auth = "==0.3.2rc6"
 mysqlclient = "==1.4.2"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "66caaf1e193232e660cd00e0d2a17d239079f8aab6b1bf8ebb73fc9012452db3"
+            "sha256": "a4be804658e5facb31a9557c81c1228da76612e44bcaa98f7d465eacb5258909"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,31 +18,44 @@
     "default": {
         "amqp": {
             "hashes": [
-                "sha256:16056c952e8029ce8db097edf0d7c2fe2ba9de15d30ba08aee2c5221273d8e23",
-                "sha256:6816eed27521293ee03aa9ace300a07215b11fee4e845588a9b863a7ba30addb"
+                "sha256:043beb485774ca69718a35602089e524f87168268f0d1ae115f28b88d27f92d7",
+                "sha256:35a3b5006ca00b21aaeec8ceea07130f07b902dd61bfe42815039835f962f5f1"
             ],
-            "version": "==2.4.1"
+            "version": "==2.4.2"
         },
         "arxiv-auth": {
             "hashes": [
-                "sha256:27272e086f190cdfd292a7008c3f3f37e9474c3ce877d81ab462ee4e6a1629c2"
+                "sha256:440b3f18a9cc0ce36fbffd5d6f565c33215f118619bc2c3f35f1c1adad74dad8"
             ],
             "index": "pypi",
-            "version": "==0.2.6"
+            "version": "==0.3.2rc6"
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:f8fa599e50550e0c6ee9de53030c22c0b8921fca7ac1268753a6b2b0fef177e9"
+                "sha256:e3872dcc34c81984fc9c8d3c0fd5a9bec8cc96852d73336fcb3683ea7d3db993"
             ],
             "index": "pypi",
-            "version": "==0.12.1"
+            "version": "==0.15.3rc1"
         },
         "astroid": {
             "hashes": [
-                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
-                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.5"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "backports-datetime-fromisoformat": {
+            "hashes": [
+                "sha256:9577a2a9486cd7383a5f58b23bb8e81cf0821dbbc0eb7c87d3fa198c1df40f5c"
+            ],
+            "version": "==1.0.0"
         },
         "billiard": {
             "hashes": [
@@ -50,19 +63,26 @@
             ],
             "version": "==3.5.0.5"
         },
+        "bleach": {
+            "hashes": [
+                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
+                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+            ],
+            "version": "==3.1.0"
+        },
         "boto3": {
             "hashes": [
-                "sha256:0bed0db8c10b88b3daa042adaa1fb6c3262caed39d28086e8548015405c71744",
-                "sha256:70e71e0192a68f65754ab9d2a335be3c6856a1e8a15f3bd6263ea12e2f442bc7"
+                "sha256:084fcb90fb1a8d4834cff2fbd842ec546f5bad334acf740ed8a16fc0ebf47f61",
+                "sha256:1a1da1d9ec446e50ec04b21a6ec6eaf37f614161d24a8ba92b92e93ad78e18fc"
             ],
-            "version": "==1.9.93"
+            "version": "==1.9.110"
         },
         "botocore": {
             "hashes": [
-                "sha256:4df39ef9bcd7766e3a71a9e7f976ca6c9e926f451914a9c073aa50e9519436ca",
-                "sha256:d3cea95919892eac30e2ff8c5a8908022d5a93f917df3cff4ed06a6926dcc0e5"
+                "sha256:995c29b9913f8ae9dc95408db48034c7040fb1b5378a2e9e1e4030167c6b80ee",
+                "sha256:b18d7b0949a613331160af20e9517a3663e0009a2edb4cb1e1177ab4fdff6c9d"
             ],
-            "version": "==1.12.93"
+            "version": "==1.12.110"
         },
         "celery": {
             "hashes": [
@@ -172,11 +192,10 @@
         },
         "isort": {
             "hashes": [
-                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+                "sha256:38a74a5ccf3a15a7a99f975071164f48d4d10eed4154879009c18e6e8933e5aa",
+                "sha256:abbb2684aa234d5eb8a67ef36d4aa62ea080d46c2eba36ad09e2990ae52e4305"
             ],
-            "version": "==4.3.4"
+            "version": "==4.3.13"
         },
         "itsdangerous": {
             "hashes": [
@@ -194,25 +213,25 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
-                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
+                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
+                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
             ],
-            "version": "==0.9.3"
+            "version": "==0.9.4"
         },
         "jsonschema": {
             "hashes": [
-                "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
-                "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
+                "sha256:0c0a81564f181de3212efa2d17de1910f8732fa1b71c42266d983cd74304e20d",
+                "sha256:a5f6559964a3851f59040d3b961de5e68e70971afb88ba519d27e6a039efff1a"
             ],
             "index": "pypi",
-            "version": "==2.6.0"
+            "version": "==3.0.1"
         },
         "kombu": {
             "hashes": [
-                "sha256:529df9e0ecc0bad9fc2b376c3ce4796c41b482cf697b78b71aea6ebe7ca353c8",
-                "sha256:7a2cbed551103db9a4e2efafe9b63222e012a61a18a881160ad797b9d4e1d0a1"
+                "sha256:750579c10e4ce82636cebdaad3cfc96970b4c7c483a040bb94fb52040bc53a48",
+                "sha256:b1a68fe8a1144eab0359be6bbae5e03b6684c98b9b53de7a17ce6d64ef24e4ea"
             ],
-            "version": "==4.3.0"
+            "version": "==4.4.0"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -250,36 +269,36 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "mccabe": {
             "hashes": [
@@ -334,11 +353,17 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
-                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
             ],
             "index": "pypi",
-            "version": "==2.2.2"
+            "version": "==2.3.1"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2"
+            ],
+            "version": "==0.14.11"
         },
         "python-dateutil": {
             "hashes": [
@@ -393,9 +418,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:52a42dbf02d0562d6e90e7af59f177f1cc027e72833cc29c3a821eefa009c71d"
+                "sha256:11ead7047ff3f394ed0d4b62aded6c5d970a9b718e1dc6add9f5e79442cc5b14"
             ],
-            "version": "==1.2.17"
+            "version": "==1.3.0"
         },
         "typed-ast": {
             "hashes": [
@@ -419,6 +444,7 @@
                 "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
                 "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
             ],
+            "markers": "implementation_name == 'cpython'",
             "version": "==1.3.1"
         },
         "urllib3": {
@@ -442,6 +468,13 @@
                 "sha256:ee4813e915d0e1a54e5c1963fde0855337f82655678540a6bc5996bca4165f76"
             ],
             "version": "==1.2.0"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         },
         "werkzeug": {
             "hashes": [
@@ -520,11 +553,11 @@
         },
         "coveralls": {
             "hashes": [
-                "sha256:ab638e88d38916a6cedbf80a9cd8992d5fa55c77ab755e262e00b36792b7cd6d",
-                "sha256:b2388747e2529fa4c669fb1e3e2756e4e07b6ee56c7d9fce05f35ccccc913aa0"
+                "sha256:6f213e461390973f4a97fb9e9d4ebd4956af296ff0a4d868e622108145835cb7",
+                "sha256:a7d0078c9e9b5692c03dcd3884647e837836c265c01e98094632feadef767d36"
             ],
             "index": "pypi",
-            "version": "==1.5.1"
+            "version": "==1.6.0"
         },
         "docopt": {
             "hashes": [

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -542,6 +542,7 @@ def upload(upload_id: Optional[int], file: FileStorage, archive: str,
             response_data = _status_data(upload_db_data, upload_workspace)
             logger.info("%s: Generating upload summary.",
                         upload_db_data.upload_id)
+            logger.debug('Response data: %s', response_data)
             return response_data, status_code, headers
 
     except IOError as e:
@@ -567,6 +568,7 @@ def upload(upload_id: Optional[int], file: FileStorage, archive: str,
 
     return None
 
+
 def upload_summary(upload_id: int) -> Response:
     """
     Provide summary of important upload workspace details.
@@ -584,11 +586,11 @@ def upload_summary(upload_id: int) -> Response:
         logs - Errors and Warnings
         files - list of file details
 
-
     int
         An HTTP status code.
     dict
         Some extra headers to add to the response.
+
     """
     try:
         # Make sure we have an upload_db_data to work with
@@ -958,8 +960,7 @@ def check_upload_content_exists(upload_id: int) -> Response:
         size = upload_workspace.content_package_size
         return {}, status.HTTP_200_OK, {'ETag': checksum,
                                         'Content-Length': size,
-                                        'Last-Modified': modified
-                                        }
+                                        'Last-Modified': modified}
 
     return {}, status.HTTP_200_OK, {'ETag': checksum}
 

--- a/filemanager/routes/tests/test_head_requests.py
+++ b/filemanager/routes/tests/test_head_requests.py
@@ -1,0 +1,96 @@
+"""Tests for routes that respond to HEAD requests."""
+
+from unittest import TestCase, mock
+
+from arxiv.users.helpers import generate_token
+from arxiv.users.auth import scopes
+from arxiv.integration.api import status
+
+from .. import upload_api
+from ...factory import create_web_app
+
+
+OS_ENVIRON = {'JWT_SECRET': 'foosecret'}
+
+
+class TestContentLengthHeader(TestCase):
+    """
+    Verify that the Content-Length header is set correctly.
+
+    Per RFC2616§14.13 the Content-Length header should be the size of the
+    entity-body were the client to retrieve the resource with a GET request.
+    """
+
+    def setUp(self):
+        self.app = create_web_app()
+        self.app.config['JWT_SECRET'] = 'foosecret'
+        self.client = self.app.test_client()
+        with self.app.app_context():
+            auth_scope = [scopes.READ_UPLOAD, scopes.READ_UPLOAD_SERVICE_LOGS,
+                          scopes.READ_UPLOAD_LOGS]
+            self.token = generate_token('123', 'foo@user.com', 'foouser',
+                                        scope=auth_scope)
+
+    @mock.patch('arxiv.users.auth.middleware.os.environ', OS_ENVIRON)
+    @mock.patch(f'{upload_api.__name__}.upload.check_upload_content_exists')
+    def test_check_upload_content_exists(self, mock_controller):
+        """HEAD request to content status endpoint returns correct length."""
+        mock_controller.return_value = {}, 200, {'Content-Length': '392351'}
+        with self.app.app_context():
+            response = self.client.head('/filemanager/api/1/content',
+                                        headers={'Authorization': self.token})
+
+        content_length = response.headers.getlist('Content-Length')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(content_length), 1, 'Only one value is returned')
+        self.assertEqual(content_length[0], '392351',
+                         'The value provided by the controller is returned')
+
+    @mock.patch('arxiv.users.auth.middleware.os.environ', OS_ENVIRON)
+    @mock.patch(f'{upload_api.__name__}.upload.check_upload_file_content_exists')
+    def test_check_file_exists(self, mock_controller):
+        """HEAD request to file status endpoint returns correct length."""
+        mock_controller.return_value = {}, 200, {'Content-Length': '392351'}
+        with self.app.app_context():
+            response = self.client.head(f'/filemanager/api/1/file.txt/content',
+                                        headers={'Authorization': self.token})
+
+        content_length = response.headers.getlist('Content-Length')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(content_length), 1, 'Only one value is returned')
+        self.assertEqual(content_length[0], '392351',
+                         'The value provided by the controller is returned')
+
+    @mock.patch('arxiv.users.auth.middleware.os.environ', OS_ENVIRON)
+    @mock.patch(f'{upload_api.__name__}.upload.check_upload_source_log_exists')
+    def test_check_upload_source_log_exists(self, mock_controller):
+        """HEAD request to source log endpoint returns correct length."""
+        mock_controller.return_value = {}, 200, {'Content-Length': '392351'}
+        with self.app.app_context():
+            response = self.client.head(f'/filemanager/api/1/log',
+                                        headers={'Authorization': self.token})
+
+        content_length = response.headers.getlist('Content-Length')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(content_length), 1, 'Only one value is returned')
+        self.assertEqual(content_length[0], '392351',
+                         'The value provided by the controller is returned')
+
+    @mock.patch('arxiv.users.auth.middleware.os.environ', OS_ENVIRON)
+    @mock.patch(f'{upload_api.__name__}.upload.check_upload_service_log_exists')
+    def test_check_upload_service_log_exists(self, mock_controller):
+        """HEAD request to service log endpoint returns correct length."""
+        mock_controller.return_value = {}, 200, {'Content-Length': '392351'}
+        with self.app.app_context():
+            response = self.client.head(f'/filemanager/api/log',
+                                        headers={'Authorization': self.token})
+
+        content_length = response.headers.getlist('Content-Length')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(content_length), 1, 'Only one value is returned')
+        self.assertEqual(content_length[0], '392351',
+                         'The value provided by the controller is returned')

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -223,22 +223,21 @@ def unrelease(upload_id: int) -> tuple:
 
 @blueprint.route('/<int:upload_id>/content', methods=['HEAD'])
 @scoped(scopes.READ_UPLOAD)
-def check_upload_content_exists(upload_id: int) -> tuple:
+def check_upload_content_exists(upload_id: int) -> Response:
     """
     Verify that upload content exists.
 
     Returns an ``ETag`` header with the current source package checksum.
     """
     data, status_code, headers = upload.check_upload_content_exists(upload_id)
-    response = jsonify(data)
-    response = _update_headers(response, headers)
+    response = _update_headers(jsonify(data), headers)
     response.status_code = status_code
     return response
 
 
 @blueprint.route('/<int:upload_id>/content', methods=['GET'])
 @scoped(scopes.READ_UPLOAD)
-def get_upload_content(upload_id: int) -> tuple:
+def get_upload_content(upload_id: int) -> Response:
     """
     Get the upload content as a compressed tarball.
 
@@ -253,9 +252,10 @@ def get_upload_content(upload_id: int) -> tuple:
     response.set_etag(headers.get('ETag'))
     return response
 
-@blueprint.route('/<int:upload_id>/<path:public_file_path>/content', methods=['HEAD'])
+@blueprint.route('/<int:upload_id>/<path:public_file_path>/content',
+                 methods=['HEAD'])
 @scoped(scopes.READ_UPLOAD)
-def check_file_exists(upload_id: int, public_file_path: str) -> tuple:
+def check_file_exists(upload_id: int, public_file_path: str) -> Response:
     """
     Verify specified file exists.
 
@@ -264,12 +264,14 @@ def check_file_exists(upload_id: int, public_file_path: str) -> tuple:
     data, status_code, headers = \
         upload.check_upload_file_content_exists(upload_id, public_file_path)
 
-    return jsonify(data), status_code, headers
+    response = _update_headers(jsonify(data), headers)
+    response.status_code = status_code
+    return response
 
 
 @blueprint.route('/<int:upload_id>/<path:public_file_path>/content', methods=['GET'])
 @scoped(scopes.READ_UPLOAD)
-def get_file_content(upload_id: int, public_file_path: str) -> tuple:
+def get_file_content(upload_id: int, public_file_path: str) -> Response:
     """
     Return content of specified file.
 
@@ -278,8 +280,8 @@ def get_file_content(upload_id: int, public_file_path: str) -> tuple:
     :return: File content.
     """
     # Note: status_code not used
-    data, _, headers = upload.get_upload_file_content(upload_id, public_file_path)
-
+    data, _, headers = \
+        upload.get_upload_file_content(upload_id, public_file_path)
     response = send_file(data, mimetype="application/*")
     response.set_etag(headers.get('ETag'))
     return response
@@ -289,7 +291,7 @@ def get_file_content(upload_id: int, public_file_path: str) -> tuple:
 
 @blueprint.route('/<int:upload_id>/log', methods=['HEAD'])
 @scoped(scopes.READ_UPLOAD_LOGS)
-def check_upload_source_log_exists(upload_id: int) -> tuple:
+def check_upload_source_log_exists(upload_id: int) -> Response:
     """
     Check that upload source log exists.
 
@@ -302,13 +304,16 @@ def check_upload_source_log_exists(upload_id: int) -> tuple:
     Returns an ``ETag`` header with the current source package checksum.
 
     """
-    data, status_code, headers = upload.check_upload_source_log_exists(upload_id)
-    return jsonify(data), status_code, headers
+    data, status_code, headers = \
+        upload.check_upload_source_log_exists(upload_id)
+    response = _update_headers(jsonify(data), headers)
+    response.status_code = status_code
+    return response
 
 
 @blueprint.route('/<int:upload_id>/log', methods=['GET'])
 @scoped(scopes.READ_UPLOAD_LOGS)
-def get_upload_source_log(upload_id: int) -> tuple:
+def get_upload_source_log(upload_id: int) -> Response:
     """
     Get upload workspace log.
 
@@ -333,7 +338,7 @@ def get_upload_source_log(upload_id: int) -> tuple:
 
 @blueprint.route('/log', methods=['HEAD'])
 @scoped(scopes.READ_UPLOAD_SERVICE_LOGS)
-def check_upload_service_log_exists() -> tuple:
+def check_upload_service_log_exists() -> Response:
     """
     Check that upload source log exists.
 
@@ -343,12 +348,14 @@ def check_upload_service_log_exists() -> tuple:
 
     """
     data, status_code, headers = upload.check_upload_service_log_exists()
-    return jsonify(data), status_code, headers
+    response = _update_headers(jsonify(data), headers)
+    response.status_code = status_code
+    return response
 
 
 @blueprint.route('/log', methods=['GET'])
 @scoped(scopes.READ_UPLOAD_SERVICE_LOGS)
-def get_upload_service_log() -> tuple:
+def get_upload_service_log() -> Response:
     """
     Get upload file manager service log.
 

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -2,6 +2,7 @@
 
 import json
 
+from typing import Dict, Any
 from flask.json import jsonify
 from flask import Blueprint, render_template, redirect, request, url_for, \
     Response, make_response, send_file
@@ -230,10 +231,7 @@ def check_upload_content_exists(upload_id: int) -> tuple:
     """
     data, status_code, headers = upload.check_upload_content_exists(upload_id)
     response = jsonify(data)
-    if 'Content-Length' in response.headers:
-        response.headers.remove('Content-Length')
-    for key, value in headers.items():
-        response.headers.add(key, value)
+    response = _update_headers(response, headers)
     response.status_code = status_code
     return response
 
@@ -307,6 +305,7 @@ def check_upload_source_log_exists(upload_id: int) -> tuple:
     data, status_code, headers = upload.check_upload_source_log_exists(upload_id)
     return jsonify(data), status_code, headers
 
+
 @blueprint.route('/<int:upload_id>/log', methods=['GET'])
 @scoped(scopes.READ_UPLOAD_LOGS)
 def get_upload_source_log(upload_id: int) -> tuple:
@@ -331,6 +330,7 @@ def get_upload_source_log(upload_id: int) -> tuple:
     response.set_etag(headers.get('ETag'))
     return response
 
+
 @blueprint.route('/log', methods=['HEAD'])
 @scoped(scopes.READ_UPLOAD_SERVICE_LOGS)
 def check_upload_service_log_exists() -> tuple:
@@ -344,6 +344,7 @@ def check_upload_service_log_exists() -> tuple:
     """
     data, status_code, headers = upload.check_upload_service_log_exists()
     return jsonify(data), status_code, headers
+
 
 @blueprint.route('/log', methods=['GET'])
 @scoped(scopes.READ_UPLOAD_SERVICE_LOGS)
@@ -390,4 +391,12 @@ def handle_exception(error: HTTPException) -> Response:
     # Each Werkzeug HTTP exception has a class attribute called ``code``; we
     # can use that to set the status code on the response.
     response = make_response(content, error.code)
+    return response
+
+
+def _update_headers(response: Response, headers: Dict[str, Any]) -> Response:
+    if 'Content-Length' in response.headers:
+        response.headers.remove('Content-Length')
+    for key, value in headers.items():
+        response.headers.add(key, value)
     return response

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -229,7 +229,13 @@ def check_upload_content_exists(upload_id: int) -> tuple:
     Returns an ``ETag`` header with the current source package checksum.
     """
     data, status_code, headers = upload.check_upload_content_exists(upload_id)
-    return jsonify(data), status_code, headers
+    response = jsonify(data)
+    if 'Content-Length' in response.headers:
+        response.headers.remove('Content-Length')
+    for key, value in headers.items():
+        response.headers.add(key, value)
+    response.status_code = status_code
+    return response
 
 
 @blueprint.route('/<int:upload_id>/content', methods=['GET'])


### PR DESCRIPTION
There was a weird bug in HEAD requests to ``check_upload_content_exists()``. Basically the ``Content-Length`` header was getting set twice: we were setting ``Content-Length`` correctly based on the size of the resource, but then Flask was also setting the header based on the size of the response. So this fix makes sure that we are only returning our (correct) header.