### PR TITLE
ARXIVNG-2020 deployment tweaks and fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ celery = "*"
 redis = "*"
 arxiv-auth = "==0.3.2rc6"
 mysqlclient = "==1.4.2"
-arxiv-vault = "==0.1.1rc13"
+arxiv-vault = "==0.1.1rc15"
 
 [dev-packages]
 coveralls = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-arxiv-base = "==0.15.4rc1"
+arxiv-base = "==0.15.8rc4"
 flask = "*"
 "nose2" = "*"
 flask-sqlalchemy = "*"
@@ -18,7 +18,7 @@ celery = "*"
 redis = "*"
 arxiv-auth = "==0.3.2rc6"
 mysqlclient = "==1.4.2"
-arxiv-vault = "==0.0.17"
+arxiv-vault = "==0.1.1rc13"
 
 [dev-packages]
 coveralls = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9d94bc7863d9aa152f238db19fd2fc04cfd727f96626bf898fd605d1cebcc438"
+            "sha256": "90a8a4b29bd126164c505e7e97615123e838a4951e91ab9def27b0a508329b9f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,10 +39,10 @@
         },
         "arxiv-vault": {
             "hashes": [
-                "sha256:3134ce386a8a5495479603321d0d7a245828685218a0a2233cde63b09404695c"
+                "sha256:a8f636a1adabea00054d8625766c450da71ec6d79623115019367977148f9f11"
             ],
             "index": "pypi",
-            "version": "==0.1.1rc13"
+            "version": "==0.1.1rc15"
         },
         "astroid": {
             "hashes": [
@@ -79,17 +79,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:59782c178af2d5acf66315fe96b3cd1dc075109c0296c384e18a6c4143c0745d",
-                "sha256:758787b5ad7c5e2aa2979b0671129491fbab00a7b84a26532cd6b9d073ed862b"
+                "sha256:98516650f72c02d0c7b47e6f0df69c19a0d1046d3973783ed7b0f093e8e81adb",
+                "sha256:aa06b240e49dbc8443bd96086c92baa0275281e0f7cc0439a328fef9ac254253"
             ],
-            "version": "==1.9.156"
+            "version": "==1.9.157"
         },
         "botocore": {
             "hashes": [
-                "sha256:00b72bc2104a2f56513bc40ce380d0605262decc9fe3b2ce840da48f257598d7",
-                "sha256:a12a817bf1faf36837bc2d371aacfb5c7c324e0e9f0b3af94b9930cfcd8d62ea"
+                "sha256:2ded06af31f9e423fcf549e35f2fa0fd618e12995e37ebc52186dbaa870316c6",
+                "sha256:473955cd4eda6121047205fc43c56ab0e0616b93651bac5e9c747fc180603fe2"
             ],
-            "version": "==1.12.156"
+            "version": "==1.12.157"
         },
         "celery": {
             "hashes": [
@@ -449,9 +449,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:91c54ca8345008fceaec987e10924bf07dcab36c442925357e5a467b36a38319"
+                "sha256:c7fef198b43ef31dfd783d094fd5ee435ce8717592e6784c45ba337254998017"
             ],
-            "version": "==1.3.3"
+            "version": "==1.3.4"
         },
         "typed-ast": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ed146e4ba471b63d3a4e1c60d2e6cf9357ed0ee354f3dcad9ffae1dfc430e371"
+            "sha256": "9d94bc7863d9aa152f238db19fd2fc04cfd727f96626bf898fd605d1cebcc438"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,18 +32,17 @@
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:2e7b82d03da925e8af2d3d3530d4e366fdbf22b274e56b6c4659a22067fcf2be"
+                "sha256:9a0f7e5f213f7debbe13c74afdee39784e8339e10a776d33af8ecab574ea08ab"
             ],
             "index": "pypi",
-            "version": "==0.15.4rc1"
+            "version": "==0.15.8rc4"
         },
         "arxiv-vault": {
             "hashes": [
-                "sha256:5e8c00d848f267a2496123dc855244c1bda94dc22ba2282d6734feb14f45ba34",
-                "sha256:9036a7a00dbd566d5bc29734c3518c85f0a6957a2b3d3393d4e8a63583757a13"
+                "sha256:3134ce386a8a5495479603321d0d7a245828685218a0a2233cde63b09404695c"
             ],
             "index": "pypi",
-            "version": "==0.0.17"
+            "version": "==0.1.1rc13"
         },
         "astroid": {
             "hashes": [
@@ -80,17 +79,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:35e23af3fcb0d38def987e1e4fc0652dd654b3eb0e4c9c8b2869cdaf289fbfa7",
-                "sha256:603572f3824be5efc683b4c2327e2ef871d52158790b16ff754cb76b356ec3b5"
+                "sha256:59782c178af2d5acf66315fe96b3cd1dc075109c0296c384e18a6c4143c0745d",
+                "sha256:758787b5ad7c5e2aa2979b0671129491fbab00a7b84a26532cd6b9d073ed862b"
             ],
-            "version": "==1.9.132"
+            "version": "==1.9.156"
         },
         "botocore": {
             "hashes": [
-                "sha256:35c46cf79cbd7fa9b25bee74972e77756e6a584beab10f7ff52abba308e5149e",
-                "sha256:f7200836d7dd77feae3af9c2e9d7769f69fb8d0ef760da635f3cb5c2ddcb8ade"
+                "sha256:00b72bc2104a2f56513bc40ce380d0605262decc9fe3b2ce840da48f257598d7",
+                "sha256:a12a817bf1faf36837bc2d371aacfb5c7c324e0e9f0b3af94b9930cfcd8d62ea"
             ],
-            "version": "==1.12.132"
+            "version": "==1.12.156"
         },
         "celery": {
             "hashes": [
@@ -164,6 +163,13 @@
             ],
             "version": "==0.6"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
+        },
         "docutils": {
             "hashes": [
                 "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
@@ -174,19 +180,19 @@
         },
         "flask": {
             "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+                "sha256:ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3",
+                "sha256:e7d32475d1de5facaa55e3958bc4ec66d3762076b074296aa50ef8fdc5b9df61"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "flask-sqlalchemy": {
             "hashes": [
-                "sha256:3bc0fac969dd8c0ace01b32060f0c729565293302f0c4269beed154b46bec50b",
-                "sha256:5971b9852b5888655f11db634e87725a9031e170f37c0ce7851cf83497f56e53"
+                "sha256:0c9609b0d72871c540a7945ea559c8fdf5455192d2db67219509aed680a3d45a",
+                "sha256:8631bbea987bc3eb0f72b1f691d47bd37ceb795e73b59ab48586d76d75a7c605"
             ],
             "index": "pypi",
-            "version": "==2.3.2"
+            "version": "==2.4.0"
         },
         "hvac": {
             "hashes": [
@@ -204,10 +210,10 @@
         },
         "isort": {
             "hashes": [
-                "sha256:01cb7e1ca5e6c5b3f235f0385057f70558b70d2f00320208825fa62887292f43",
-                "sha256:268067462aed7eb2a1e237fcb287852f22077de3fb07964e87e00f829eea2d1a"
+                "sha256:c40744b6bc5162bbb39c1257fe298b7a393861d50978b565f3ccd9cb9de0182a",
+                "sha256:f57abacd059dc3bd666258d1efb0377510a89777fda3e3274e3c01f7c03ae22d"
             ],
-            "version": "==4.3.17"
+            "version": "==4.3.20"
         },
         "itsdangerous": {
             "hashes": [
@@ -247,37 +253,26 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
-                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
-                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
-                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
-                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
-                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
-                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
-                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
-                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
-                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
-                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
-                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
-                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
-                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
-                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
-                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
-                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
-                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
-                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
-                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
-                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
-                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
-                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
-                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
-                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
-                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
-                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
-                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
-                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+                "sha256:159a745e61422217881c4de71f9eafd9d703b93af95618635849fe469a283661",
+                "sha256:23f63c0821cc96a23332e45dfaa83266feff8adc72b9bcaef86c202af765244f",
+                "sha256:3b11be575475db2e8a6e11215f5aa95b9ec14de658628776e10d96fa0b4dac13",
+                "sha256:3f447aff8bc61ca8b42b73304f6a44fa0d915487de144652816f950a3f1ab821",
+                "sha256:4ba73f6089cd9b9478bc0a4fa807b47dbdb8fad1d8f31a0f0a5dbf26a4527a71",
+                "sha256:4f53eadd9932055eac465bd3ca1bd610e4d7141e1278012bd1f28646aebc1d0e",
+                "sha256:64483bd7154580158ea90de5b8e5e6fc29a16a9b4db24f10193f0c1ae3f9d1ea",
+                "sha256:6f72d42b0d04bfee2397aa1862262654b56922c20a9bb66bb76b6f0e5e4f9229",
+                "sha256:7c7f1ec07b227bdc561299fa2328e85000f90179a2f44ea30579d38e037cb3d4",
+                "sha256:7c8b1ba1e15c10b13cad4171cfa77f5bb5ec2580abc5a353907780805ebe158e",
+                "sha256:8559b94b823f85342e10d3d9ca4ba5478168e1ac5658a8a2f18c991ba9c52c20",
+                "sha256:a262c7dfb046f00e12a2bdd1bafaed2408114a89ac414b0af8755c696eb3fc16",
+                "sha256:acce4e3267610c4fdb6632b3886fe3f2f7dd641158a843cf6b6a68e4ce81477b",
+                "sha256:be089bb6b83fac7f29d357b2dc4cf2b8eb8d98fe9d9ff89f9ea6012970a853c7",
+                "sha256:bfab710d859c779f273cc48fb86af38d6e9210f38287df0069a63e40b45a2f5c",
+                "sha256:c10d29019927301d524a22ced72706380de7cfc50f767217485a912b4c8bd82a",
+                "sha256:dd6e2b598849b3d7aee2295ac765a578879830fb8966f70be8cd472e6069932e",
+                "sha256:e408f1eacc0a68fed0c08da45f31d0ebb38079f043328dce69ff133b95c29dc1"
             ],
-            "version": "==1.3.1"
+            "version": "==1.4.1"
         },
         "markupsafe": {
             "hashes": [
@@ -358,6 +353,13 @@
             "index": "pypi",
             "version": "==0.9.1"
         },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
         "pycountry": {
             "hashes": [
                 "sha256:104a8ca94c700898c42a0172da2eab5a5675c49637b729a11db9e1dac2d983cd",
@@ -383,9 +385,9 @@
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2"
+                "sha256:16692ee739d42cf5e39cef8d27649a8c1fdb7aa99887098f1460057c5eb75c3a"
             ],
-            "version": "==0.14.11"
+            "version": "==0.15.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -418,11 +420,18 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "index": "pypi",
-            "version": "==2.21.0"
+            "version": "==2.22.0"
+        },
+        "retry": {
+            "hashes": [
+                "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606",
+                "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"
+            ],
+            "version": "==0.9.2"
         },
         "s3transfer": {
             "hashes": [
@@ -446,29 +455,28 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:04894d268ba6eab7e093d43107869ad49e7b5ef40d1a94243ea49b352061b200",
-                "sha256:16616ece19daddc586e499a3d2f560302c11f122b9c692bc216e821ae32aa0d0",
-                "sha256:252fdae740964b2d3cdfb3f84dcb4d6247a48a6abe2579e8029ab3be3cdc026c",
-                "sha256:2af80a373af123d0b9f44941a46df67ef0ff7a60f95872412a145f4500a7fc99",
-                "sha256:2c88d0a913229a06282b285f42a31e063c3bf9071ff65c5ea4c12acb6977c6a7",
-                "sha256:2ea99c029ebd4b5a308d915cc7fb95b8e1201d60b065450d5d26deb65d3f2bc1",
-                "sha256:3d2e3ab175fc097d2a51c7a0d3fda442f35ebcc93bb1d7bd9b95ad893e44c04d",
-                "sha256:4766dd695548a15ee766927bf883fb90c6ac8321be5a60c141f18628fb7f8da8",
-                "sha256:56b6978798502ef66625a2e0f80cf923da64e328da8bbe16c1ff928c70c873de",
-                "sha256:5cddb6f8bce14325b2863f9d5ac5c51e07b71b462361fd815d1d7706d3a9d682",
-                "sha256:644ee788222d81555af543b70a1098f2025db38eaa99226f3a75a6854924d4db",
-                "sha256:64cf762049fc4775efe6b27161467e76d0ba145862802a65eefc8879086fc6f8",
-                "sha256:68c362848d9fb71d3c3e5f43c09974a0ae319144634e7a47db62f0f2a54a7fa7",
-                "sha256:6c1f3c6f6635e611d58e467bf4371883568f0de9ccc4606f17048142dec14a1f",
-                "sha256:b213d4a02eec4ddf622f4d2fbc539f062af3788d1f332f028a2e19c42da53f15",
-                "sha256:bb27d4e7805a7de0e35bd0cb1411bc85f807968b2b0539597a49a23b00a622ae",
-                "sha256:c9d414512eaa417aadae7758bc118868cd2396b0e6138c1dd4fda96679c079d3",
-                "sha256:f0937165d1e25477b01081c4763d2d9cdc3b18af69cb259dd4f640c9b900fe5e",
-                "sha256:fb96a6e2c11059ecf84e6741a319f93f683e440e341d4489c9b161eca251cf2a",
-                "sha256:fc71d2d6ae56a091a8d94f33ec9d0f2001d1cb1db423d8b4355debfe9ce689b7"
+                "sha256:132eae51d6ef3ff4a8c47c393a4ef5ebf0d1aecc96880eb5d6c8ceab7017cc9b",
+                "sha256:18141c1484ab8784006c839be8b985cfc82a2e9725837b0ecfa0203f71c4e39d",
+                "sha256:2baf617f5bbbfe73fd8846463f5aeafc912b5ee247f410700245d68525ec584a",
+                "sha256:3d90063f2cbbe39177e9b4d888e45777012652d6110156845b828908c51ae462",
+                "sha256:4304b2218b842d610aa1a1d87e1dc9559597969acc62ce717ee4dfeaa44d7eee",
+                "sha256:4983ede548ffc3541bae49a82675996497348e55bafd1554dc4e4a5d6eda541a",
+                "sha256:5315f4509c1476718a4825f45a203b82d7fdf2a6f5f0c8f166435975b1c9f7d4",
+                "sha256:6cdfb1b49d5345f7c2b90d638822d16ba62dc82f7616e9b4caa10b72f3f16649",
+                "sha256:7b325f12635598c604690efd7a0197d0b94b7d7778498e76e0710cd582fd1c7a",
+                "sha256:8d3b0e3b8626615826f9a626548057c5275a9733512b137984a68ba1598d3d2f",
+                "sha256:8f8631160c79f53081bd23446525db0bc4c5616f78d04021e6e434b286493fd7",
+                "sha256:912de10965f3dc89da23936f1cc4ed60764f712e5fa603a09dd904f88c996760",
+                "sha256:b010c07b975fe853c65d7bbe9d4ac62f1c69086750a574f6292597763781ba18",
+                "sha256:c908c10505904c48081a5415a1e295d8403e353e0c14c42b6d67f8f97fae6616",
+                "sha256:c94dd3807c0c0610f7c76f078119f4ea48235a953512752b9175f9f98f5ae2bd",
+                "sha256:ce65dee7594a84c466e79d7fb7d3303e7295d16a83c22c7c4037071b059e2c21",
+                "sha256:eaa9cfcb221a8a4c2889be6f93da141ac777eb8819f077e1d09fb12d00a09a93",
+                "sha256:f3376bc31bad66d46d44b4e6522c5c21976bf9bca4ef5987bb2bf727f4506cbb",
+                "sha256:f9202fa138544e13a4ec1a6792c35834250a85958fde1251b6a22e07d1260ae7"
             ],
             "markers": "implementation_name == 'cpython'",
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         },
         "typing-extensions": {
             "hashes": [
@@ -480,11 +488,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.24.2"
+            "version": "==1.25.3"
         },
         "uwsgi": {
             "hashes": [
@@ -509,10 +517,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a",
-                "sha256:7fad9770a8778f9576693f0cc29c7dcc36964df916b83734f4431c0e612a7fbc"
+                "sha256:865856ebb55c4dcd0630cdd8f3331a1847a819dda7e8c750d3db6f2aa6c0209c",
+                "sha256:a0b915f0815982fb2a09161cb8f31708052d0951c3ba433ccc5e1aa276507ca6"
             ],
-            "version": "==0.15.2"
+            "version": "==0.15.4"
         },
         "wrapt": {
             "hashes": [
@@ -595,19 +603,19 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "index": "pypi",
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.24.2"
+            "version": "==1.25.3"
         }
     }
 }

--- a/deploy/filemanager/templates/10-deployment.yaml
+++ b/deploy/filemanager/templates/10-deployment.yaml
@@ -21,7 +21,7 @@ metadata:
     env: "{{ .Values.namespace }}"
   namespace: "{{ .Values.namespace }}"
 spec:
-  replicas: {{ default 1 .Values.replicas }}
+  replicas: {{ int .Values.scaling.replicas }}
   template:
     metadata:
       labels:

--- a/deploy/filemanager/templates/10-deployment.yaml
+++ b/deploy/filemanager/templates/10-deployment.yaml
@@ -75,6 +75,8 @@ spec:
           value: /data
         - name: APPLICATION_ROOT
           value: "{{ .Values.ingress.path }}"
+        - name: NAMESPACE
+          value: "{{ .Values.namespace }}"
 
         volumeMounts:
         - mountPath: /data

--- a/deploy/filemanager/templates/10-deployment.yaml
+++ b/deploy/filemanager/templates/10-deployment.yaml
@@ -73,6 +73,8 @@ spec:
           value: "{{ .Values.database.host }}"
         - name: UPLOAD_BASE_DIRECTORY
           value: /data
+        - name: APPLICATION_ROOT
+          value: "{{ .Values.ingress.path }}"
 
         volumeMounts:
         - mountPath: /data

--- a/deploy/filemanager/templates/30-ingress.yaml
+++ b/deploy/filemanager/templates/30-ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ default "filemanager" .Values.ingress.name }}"
+  namespace: "{{ .Values.namespace }}"
+  labels:
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: "{{ default "filemanager" .Values.deployment.name }}"
+    service-group: api
+  annotations:
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Request-Id: $req_id";
+    ingress.kubernetes.io/limit-connections: "4"
+    ingress.kubernetes.io/limit-rps: "16"
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  tls:  # This will use the default certificate for the ingress controller.
+  - hosts:
+    - "{{ .Values.ingress.host }}"
+  rules:
+  - host: "{{ .Values.ingress.host }}"
+    http:
+      paths:
+      - path: "{{ default "/filemanager" .Values.ingress.path }}"
+        backend:
+          serviceName: "{{ default "filemanager" .Values.service.name }}"
+          servicePort: 80

--- a/deploy/filemanager/templates/30-ingress.yaml
+++ b/deploy/filemanager/templates/30-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
       more_set_headers "Request-Id: $req_id";
     ingress.kubernetes.io/limit-connections: "4"
     ingress.kubernetes.io/limit-rps: "16"
-    ingress.kubernetes.io/rewrite-target: /
+    ingress.kubernetes.io/rewrite-target: /filemanager/api
 spec:
   tls:  # This will use the default certificate for the ingress controller.
   - hosts:

--- a/deploy/filemanager/values.yaml
+++ b/deploy/filemanager/values.yaml
@@ -19,3 +19,7 @@ database:
   host: changeme
 
 loglevel: 10
+
+ingress:
+  host: "development.arxiv.org"
+  path: "/source"

--- a/deploy/filemanager/values.yaml
+++ b/deploy/filemanager/values.yaml
@@ -8,7 +8,8 @@ image:
 labels:
   subsystem: submission
 
-replicas: 1
+scaling:
+  replicas: 3
 
 vault:
   host: changeme

--- a/filemanager/config.py
+++ b/filemanager/config.py
@@ -89,7 +89,7 @@ VAULT_REQUESTS = [
      'database': os.environ.get('FILEMANAGER_DATABASE', 'filemanager'),
      'params': 'charset=utf8mb4',
      'port': '3306',
-     'name': 'FILE_MANAGEMENT_SQLALCHEMY_DATABASE_URI',
+     'name': 'SQLALCHEMY_DATABASE_URI',
      'mount_point': f'database{NS_AFFIX}/',
      'role': 'filemanager-write'}
 ]

--- a/filemanager/config.py
+++ b/filemanager/config.py
@@ -4,6 +4,9 @@ import os
 
 VERSION = '0.2'
 
+NAMESPACE = os.environ.get('NAMESPACE')
+"""Namespace in which this service is deployed; to qualify keys for secrets."""
+
 SECRET_KEY = os.environ.get('SECRET_KEY', 'asdf1234')
 SERVER_NAME = os.environ.get('ARXIV_FILE_MANAGMENT')
 
@@ -50,16 +53,33 @@ MAX_CONTENT_LENGTH = 16 * 1024 * 1024
 UPLOAD_BASE_DIRECTORY = os.environ.get('UPLOAD_BASE_DIRECTORY',
                                        '/tmp/filemanagment/submissions')
 
+NS_AFFIX = '' if NAMESPACE == 'production' else f'-{NAMESPACE}'
+
 KUBE_TOKEN = os.environ.get('KUBE_TOKEN', 'fookubetoken')
+"""Service account token for authenticating with Vault. May be a file path."""
+
 VAULT_ENABLED = bool(int(os.environ.get('VAULT_ENABLED', '0')))
+"""Enable/disable secret retrieval from Vault."""
+
 VAULT_HOST = os.environ.get('VAULT_HOST', 'foovaulthost')
+"""Vault hostname/address."""
+
 VAULT_PORT = os.environ.get('VAULT_PORT', '1234')
+"""Vault API port."""
+
 VAULT_ROLE = os.environ.get('VAULT_ROLE', 'filemanager')
+"""Vault role linked to this application's service account."""
+
 VAULT_CERT = os.environ.get('VAULT_CERT')
+"""Path to CA certificate for TLS verification when talking to Vault."""
+
+VAULT_SCHEME = os.environ.get('VAULT_SCHEME', 'https')
+"""Default is ``https``."""
+
 VAULT_REQUESTS = [
     {'type': 'generic',
      'name': 'JWT_SECRET',
-     'mount_point': 'secret-development/',
+     'mount_point': f'secret{NS_AFFIX}/',
      'path': 'jwt',
      'key': 'jwt-secret',
      'minimum_ttl': 60},
@@ -70,6 +90,7 @@ VAULT_REQUESTS = [
      'params': 'charset=utf8mb4',
      'port': '3306',
      'name': 'FILE_MANAGEMENT_SQLALCHEMY_DATABASE_URI',
-     'mount_point': 'database-development/',
+     'mount_point': f'database{NS_AFFIX}/',
      'role': 'filemanager-write'}
 ]
+"""Requests for Vault secrets."""

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -278,7 +278,8 @@ def client_delete_file(upload_id: int, public_file_path: str) -> Response:
         'reason': UPLOAD_DELETED_FILE,
         'checksum': upload_workspace.content_checksum()
     })  # Get rid of pylint errorT
-    return response_data, status.OK, {}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id}
+    return response_data, status.OK, headers
 
 
 def client_delete_all_files(upload_id: int) -> Response:
@@ -344,7 +345,8 @@ def client_delete_all_files(upload_id: int) -> Response:
         'reason': UPLOAD_DELETED_ALL_FILES,
         'checksum': upload_workspace.content_checksum()
     })  # Get rid of pylint error
-    return response_data, status.OK, {}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id}
+    return response_data, status.OK, headers
 
 
 def upload(upload_id: Optional[int], file: FileStorage, archive: str,
@@ -539,6 +541,7 @@ def upload(upload_id: Optional[int], file: FileStorage, archive: str,
         logger.info("%s: Generating upload summary.",
                     upload_db_data.upload_id)
         logger.debug('Response data: %s', response_data)
+        headers.update({'ARXIV-OWNER': upload_db_data.owner_user_id})
         return response_data, status_code, headers
 
     except IOError as e:
@@ -636,7 +639,8 @@ def upload_summary(upload_id: int) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    return response_data, status_code, {}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id}
+    return response_data, status_code, headers
 
 
 # TODO: How do we keep submitter from updating workspace while admin
@@ -700,7 +704,8 @@ def upload_lock(upload_id: int) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    return response_data, status_code, {}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id}
+    return response_data, status_code, headers
 
 
 def upload_unlock(upload_id: int) -> Response:
@@ -753,7 +758,8 @@ def upload_unlock(upload_id: int) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    return response_data, status_code, {}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id}
+    return response_data, status_code, headers
 
 
 def upload_release(upload_id: int) -> Response:
@@ -829,7 +835,8 @@ def upload_release(upload_id: int) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    return response_data, status_code, {}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id}
+    return response_data, status_code, headers
 
 
 def upload_unrelease(upload_id: int) -> Response:
@@ -910,7 +917,8 @@ def upload_unrelease(upload_id: int) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    return response_data, status_code, {}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id}
+    return response_data, status_code, headers
 
 
 # Content download controllers
@@ -954,8 +962,8 @@ def check_upload_content_exists(upload_id: int) -> Response:
         return {}, status.OK, {'ETag': checksum,
                                         'Content-Length': size,
                                         'Last-Modified': modified}
-
-    return {}, status.OK, {'ETag': checksum}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id, 'ETag': checksum}
+    return {}, status.OK, headers
 
 
 def get_upload_content(upload_id: int) -> Response:
@@ -989,7 +997,8 @@ def get_upload_content(upload_id: int) -> Response:
         raise NotFound("No content in workspace") from e
     headers = {
         "Content-disposition": f"filename={filepointer.name}",
-        'ETag': checksum
+        'ETag': checksum,
+        'ARXIV-OWNER': upload_db_data.owner_user_id
     }
     return filepointer, status.OK, headers
 
@@ -1057,7 +1066,8 @@ def check_upload_file_content_exists(upload_id: int, public_file_path: str) -> R
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
-    return {}, status.OK, {'ETag': checksum}
+    headers = {'ARXIV-OWNER': upload_db_data.owner_user_id, 'ETag': checksum}
+    return {}, status.OK, headers
 
 
 def get_upload_file_content(upload_id: int, public_file_path: str) -> Response:
@@ -1129,6 +1139,7 @@ def get_upload_file_content(upload_id: int, public_file_path: str) -> Response:
                     " Add except clauses for '%s'. DO IT NOW!", ue)
         raise InternalServerError(UPLOAD_UNKNOWN_ERROR)
 
+    headers.update({'ARXIV-OWNER': upload_db_data.owner_user_id})
     return filepointer, status.OK, headers
 
 
@@ -1169,9 +1180,13 @@ def check_upload_source_log_exists(upload_id: int) -> Response:
     size = upload_workspace.source_log_size
     modified = upload_workspace.source_log_last_modified
 
-    return {}, status.OK, {'ETag': checksum,
-                                    'Content-Length': size,
-                                    'Last-Modified': modified}
+    headers = {
+        'ETag': checksum,
+        'Content-Length': size,
+        'Last-Modified': modified,
+        'ARXIV-OWNER': upload_db_data.owner_user_id
+    }
+    return {}, status.OK, headers
 
 
 def get_upload_source_log(upload_id: int) -> Response:
@@ -1216,7 +1231,8 @@ def get_upload_source_log(upload_id: int) -> Response:
         "Content-disposition": f"filename={name}",
         'ETag': checksum,
         'Content-Length': size,
-        'Last-Modified': modified
+        'Last-Modified': modified,
+        'ARXIV-OWNER': upload_db_data.owner_user_id
     }
     return filepointer, status.OK, headers
 

--- a/filemanager/factory.py
+++ b/filemanager/factory.py
@@ -1,7 +1,5 @@
 """Application factory for file management app."""
 
-#import logging
-
 from flask import Flask, jsonify, Response
 from werkzeug.exceptions import HTTPException, Forbidden, Unauthorized, \
     BadRequest, MethodNotAllowed, InternalServerError, NotFound

--- a/filemanager/factory.py
+++ b/filemanager/factory.py
@@ -38,8 +38,12 @@ def create_web_app() -> Flask:
         middleware.insert(0, vault.middleware.VaultMiddleware)
     wrap(app, middleware)
 
+    if app.config['VAULT_ENABLED']:
+        app.middlewares['VaultMiddleware'].update_secrets({})
+
     celery_app.config_from_object(celeryconfig)
-    celery_app.autodiscover_tasks(['filemanager'], related_name='tasks', force=True)
+    celery_app.autodiscover_tasks(['filemanager'], related_name='tasks',
+                                  force=True)
     celery_app.conf.task_default_queue = 'filemanager-worker'
 
     return app

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -2,12 +2,15 @@
 http-socket = :8000
 chdir = /opt/arxiv/
 wsgi-file = wsgi.py
-processes = 8
-threads = 1
-async = 100
-timeout 3000
-manage-script-name = true
+callable = application
 master = true
-ugreen = true
-uid = nobody
-stats = /tmp/stats.socket
+harakiri = 3000
+manage-script-name = true
+processes = 1
+queue = 0
+threads = 1
+single-interpreter = true
+mount = $(APPLICATION_ROOT)=wsgi.py
+logformat = "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \"%(method) %(uri) %(proto)\" %(status) %(size) %(micros) %(ttfb)"
+buffer-size = 65535
+wsgi-disable-file-wrapper = true

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -6,9 +6,8 @@ callable = application
 master = true
 harakiri = 3000
 manage-script-name = true
-processes = 1
-queue = 0
-threads = 1
+processes = 8
+vacuum = true
 single-interpreter = true
 mount = $(APPLICATION_ROOT)=wsgi.py
 logformat = "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \"%(method) %(uri) %(proto)\" %(status) %(size) %(micros) %(ttfb)"

--- a/wsgi.py
+++ b/wsgi.py
@@ -13,4 +13,5 @@ def application(environ, start_response):
         if key == 'SERVER_NAME':    # This will only confuse Flask.
             continue
         os.environ[key] = str(value)
+        __flask_app__.config[key] = value
     return __flask_app__(environ, start_response)


### PR DESCRIPTION
A variety of little tweaks for deployment, in support of https://github.com/arXiv/arxiv-submission-ui/pull/80

- Adds the ``ARXIV-OWNER`` header to API responses
- Adds error handlers that turn HTTP exceptions into JSON responses
- Additions/changes to Helm deployment config