### PR TITLE
Errors and warnings

### DIFF
--- a/filemanager/domain/__init__.py
+++ b/filemanager/domain/__init__.py
@@ -5,5 +5,5 @@ from .uploads import UserFile, Workspace, IChecker, SourceLog, SourceType, \
     Status, LockState
 from .file_type import FileType
 from .uploads import ICheckingStrategy
-from .error import Error
+from .error import Error, Severity, Code
 from .index import NoSuchFile, FileIndex

--- a/filemanager/domain/error.py
+++ b/filemanager/domain/error.py
@@ -6,25 +6,23 @@ from typing import Optional, Dict, Any
 from dataclasses import dataclass, field
 
 
+class Severity(Enum):
+    """Severity levels for errors."""
+
+    FATAL = 'fatal'
+    WARNING = 'warn'
+    INFO = 'info'
+
+
+# This is not an enum, because we want checkers to define and maintain their
+# own codes.
+Code = str
+UNKNOWN: Code = 'unknown_error'
+
+
 @dataclass
 class Error:
     """Represents an error related to file processing."""
-
-    class Severity(Enum):
-        """Severity levels for errors."""
-
-        FATAL = 'fatal'
-        WARNING = 'warn'
-        INFO = 'info'
-
-    class Code(Enum):
-        """
-        Known error conditions.
-
-        Not implemented.
-        """
-
-        UNKNOWN = -1
 
     severity: Severity
     """Severity level of this error."""
@@ -32,8 +30,8 @@ class Error:
     message: str
     """Human-readable error message."""
 
-    code: Code = field(default=Code.UNKNOWN)
-    """Specific code for this error. Not implemented."""
+    code: Code = field(default=UNKNOWN)
+    """Specific code for this error."""
 
     path: Optional[str] = field(default=None)
     """Optional path for file associated with this error."""
@@ -41,11 +39,22 @@ class Error:
     is_persistant: bool = field(default=True)
     """Indicates whether or not this error sticks around between requests."""
 
+    @property
+    def is_fatal(self) -> bool:
+        """Indicates whether this is a fatal error."""
+        return bool(self.severity == Severity.FATAL)
+
+    @property
+    def is_warning(self) -> bool:
+        """Indicates whether this is is a warning."""
+        return bool(self.severity == Severity.WARNING)
+
     def to_dict(self) -> Dict[str, Any]:
+        """Generate a dict representation of this error."""
         return {
             'severity': self.severity.value,
             'message': self.message,
-            'code': self.code.value,
+            'code': self.code,
             'path': self.path,
             'is_persistant': self.is_persistant
         }
@@ -54,9 +63,9 @@ class Error:
     def from_dict(cls, data: dict) -> 'Error':
         """Translate a dict to an :class:`.Error`."""
         return cls(
-            severity=cls.Severity(data['severity']),
+            severity=Severity(data['severity']),
             message=data['message'],
-            code=cls.Code(data.get('code', cls.Code.UNKNOWN.value)),
+            code=data.get('code', UNKNOWN),
             path=data.get('path', None),
             is_persistant=data.get('is_persistant', True)
         )

--- a/filemanager/domain/index.py
+++ b/filemanager/domain/index.py
@@ -25,8 +25,12 @@ class FileIndex:
     removed: Dict[str, UserFile] = field(default_factory=dict)
     system: Dict[str, UserFile] = field(default_factory=dict)
 
-    def set(self, path: str, u_file: UserFile) -> None:
+    def add(self, u_file: UserFile) -> None:
         """Add a :class:`.UserFile` to the index."""
+        self.set(u_file.path, u_file)
+
+    def set(self, path: str, u_file: UserFile) -> None:
+        """Add a :class:`.UserFile` to the index at ``path``."""
         if u_file.is_system:
             self.system[path] = u_file  # pylint: disable=unsupported-assignment-operation
         elif u_file.is_removed:

--- a/filemanager/domain/uploads/checkpoint.py
+++ b/filemanager/domain/uploads/checkpoint.py
@@ -190,7 +190,7 @@ class Checkpointable(ICheckpointable):
         if self._all_file_count == 0:
             raise NoSourceFilesToCheckpoint(UPLOAD_WORKSPACE_IS_EMPTY)
 
-        self.__api.add_warning_non_file(
+        self.__api.log.info(
             "Creating checkpoint." + (f"['{user.user_id}']" if user else "")
         )
 
@@ -426,4 +426,4 @@ class Checkpointable(ICheckpointable):
         self.__api.files.ancillary = workspace.files.ancillary
         for u_file in self.__api.iter_files():
             u_file.workspace = cast(IWorkspace, self)
-        self._errors = workspace.errors
+        self._errors = {(e.path, e.code): e for e in workspace.errors}

--- a/filemanager/domain/uploads/checkpoint.py
+++ b/filemanager/domain/uploads/checkpoint.py
@@ -16,7 +16,7 @@ from arxiv.util.serialize import ISO8601JSONEncoder, ISO8601JSONDecoder  # pylin
 
 from .base import IBaseWorkspace
 from .exceptions import UploadFileSecurityError, NoSourceFilesToCheckpoint
-from ..error import Error
+from ..error import Error, Severity
 from ..uploaded_file import UserFile
 
 UPLOAD_WORKSPACE_IS_EMPTY = 'workspace is empty'
@@ -57,8 +57,7 @@ class IWorkspace(IBaseWorkspace, Protocol):
                              is_persistant: bool = False) -> None:
         """Add a warning for the workspace that is not specific to a file."""
 
-    def add_error_non_file(self, msg: str,
-                           severity: Error.Severity = Error.Severity.FATAL,
+    def add_error_non_file(self, msg: str, severity: Severity = Severity.FATAL,
                            is_persistant: bool = True) -> None:
         """Add an error for the workspace that is not specific to a file."""
 

--- a/filemanager/domain/uploads/errors_and_warnings.py
+++ b/filemanager/domain/uploads/errors_and_warnings.py
@@ -1,12 +1,12 @@
 """Provides :class:`.ErrorsAndWarnings`."""
 
-from typing import List, Optional, Any, Iterator, Dict, Callable, cast
+from typing import List, Optional, Any, Iterator, Dict, Callable, Tuple, cast
 
 from dataclasses import dataclass, field
 from typing_extensions import Protocol
 
 from ..uploaded_file import UserFile
-from ..error import Error
+from ..error import Error, Code, Severity
 from ..index import FileIndex
 from .base import IBaseWorkspace
 
@@ -55,21 +55,21 @@ class IErrorsAndWarnings(Protocol):
     def warnings_active(self) -> List[Error]:
         """Warnings for active files only."""
 
-    def add_error(self, u_file: UserFile, msg: str,
-                  severity: Error.Severity = Error.Severity.FATAL,
+    def add_error(self, u_file: UserFile, code: Code, msg: str,
+                  severity: Severity = Severity.FATAL,
                   is_persistant: bool = True) -> None:
         """Add an error for a specific file."""
 
-    def add_error_non_file(self, msg: str,
-                           severity: Error.Severity = Error.Severity.FATAL,
+    def add_error_non_file(self, code: Code, msg: str,
+                           severity: Severity = Severity.FATAL,
                            is_persistant: bool = True) -> None:
         """Add an error for the workspace that is not specific to a file."""
 
-    def add_warning(self, u_file: UserFile, msg: str,
+    def add_warning(self, u_file: UserFile, code: Code, msg: str,
                     is_persistant: bool = True) -> None:
         """Add a warning for a specific file."""
 
-    def add_warning_non_file(self, msg: str,
+    def add_warning_non_file(self, code: Code, msg: str,
                              is_persistant: bool = False) -> None:
         """Add a warning for the workspace that is not specific to a file."""
 
@@ -79,16 +79,21 @@ class IErrorsAndWarnings(Protocol):
                      is_removed: bool = False) -> List[str]:
         """Get all warnings for the file at ``path``."""
 
+    def remove_error(self, code: Code, path: Optional[str] = None) -> None:
+        """Remove an error."""
+
 
 class IErrorsAndWarningsWorkspace(IWorkspace, IErrorsAndWarnings, Protocol):
     """Interface for workspace with errors and warnings behavior."""
 
+Path = Optional[str]
 
 @dataclass
 class ErrorsAndWarnings(IErrorsAndWarnings):
     """Adds methods for handling errors and warnings."""
 
-    _errors: List[Error] = field(default_factory=list)
+    # _errors: List[Error] = field(default_factory=list)
+    _errors: Dict[Tuple[Path, Code], Error] = field(default_factory=dict)
 
     __internal_api = None
 
@@ -117,31 +122,25 @@ class ErrorsAndWarnings(IErrorsAndWarnings):
                 # The protected access is safe, given that this is for all
                 # intents and purposes an instancemethod without instance
                 # binding.
-                workspace._errors.append(e)  # pylint: disable=protected-access
+                # workspace._errors.append(e)  # pylint: disable=protected-access
+                workspace._errors[(e.path, e.code)] = e  # pylint: disable=protected-access
 
     @classmethod    # See comment for post_from_dict, above.
     def to_dict_impl(cls, self: 'ErrorsAndWarnings') -> Dict[str, Any]:
         """Generate a dict representation of errors."""
-        return {'errors': [e.to_dict() for e          # See comment above.
-                in self._errors if e.is_persistant]}  # pylint: disable=protected-access
+        # See comment above.
+        return {'errors': [e.to_dict() for e in self._errors.values()  # pylint: disable=protected-access
+                if e.is_persistant]}
 
     @property
     def errors(self) -> List[Error]:
         """All of the errors + warnings in the workspace."""
-        return [error for u_file in self.__api.files
-                for error in u_file.errors] + self._errors
+        return self._errors_files + list(self._errors.values())
 
     @property
     def errors_fatal(self) -> List[Error]:
         """All of the fatal errors on active files in the workspace."""
-        return (
-            [error for u_file in self.__api.files
-             for error in u_file.errors
-             if u_file.is_active and error.severity is Error.Severity.FATAL]
-            +
-            [error for error in self._errors
-             if error.severity is Error.Severity.FATAL]
-        )
+        return self._errors_fatal_files + self._errors_fatal
 
     @property
     def has_errors(self) -> bool:
@@ -173,30 +172,55 @@ class ErrorsAndWarnings(IErrorsAndWarnings):
         """Warnings for active files only."""
         return self._get_warnings(is_active=True)
 
-    def add_error(self, u_file: UserFile, msg: str,
-                  severity: Error.Severity = Error.Severity.FATAL,
+    @property
+    def _errors_files(self) -> List[Error]:
+        return [e for u_file in self.__api.files for e in u_file.errors]
+
+    @property
+    def _errors_fatal_files(self) -> List[Error]:
+        return [e for u_file in self.__api.files for e in u_file.errors
+                if u_file.is_active and e.is_fatal]
+
+    @property
+    def _errors_fatal(self) -> List[Error]:
+        return [e for e in self._errors.values() if e.is_fatal]
+
+    @property
+    def _warnings(self) -> List[Error]:
+        return [e for e in self._errors.values() if e.is_warning]
+
+    def add_error(self, u_file: UserFile, code: Code, msg: str,
+                  severity: Severity = Severity.FATAL,
                   is_persistant: bool = True) -> None:
         """Add an error for a specific file."""
-        u_file.add_error(Error(severity=severity, path=u_file.path,
-                               message=msg, is_persistant=is_persistant))
+        e = Error(severity=severity, path=u_file.path, code=code,
+                  message=msg, is_persistant=is_persistant)
+        u_file.add_error(e)
 
-    def add_error_non_file(self, msg: str,
-                           severity: Error.Severity = Error.Severity.FATAL,
+    def remove_error(self, code: Code, path: Optional[str] = None) -> None:
+        if path is None:
+            self._remove_error(code, path)
+        else:
+            self.__api.get(path).remove_error(code)
+
+
+    def add_error_non_file(self, code: Code, msg: str,
+                           severity: Severity = Severity.FATAL,
                            is_persistant: bool = True) -> None:
         """Add an error for the workspace that is not specific to a file."""
-        self._errors.append(Error(severity=severity, path=None, message=msg,
-                                  is_persistant=is_persistant))
+        self._insert_error(Error(severity=severity, path=None, code=code,
+                           message=msg, is_persistant=is_persistant))
 
-    def add_warning(self, u_file: UserFile, msg: str,
+    def add_warning(self, u_file: UserFile, code: Code, msg: str,
                     is_persistant: bool = True) -> None:
         """Add a warning for a specific file."""
-        self.add_error(u_file, msg, severity=Error.Severity.WARNING,
+        self.add_error(u_file, code, msg, severity=Severity.WARNING,
                        is_persistant=is_persistant)
 
-    def add_warning_non_file(self, msg: str,
+    def add_warning_non_file(self, code: Code, msg: str,
                              is_persistant: bool = False) -> None:
         """Add a warning for the workspace that is not specific to a file."""
-        self.add_error_non_file(msg, severity=Error.Severity.WARNING,
+        self.add_error_non_file(code, msg, severity=Severity.WARNING,
                                 is_persistant=is_persistant)
 
     def get_warnings(self, path: str,
@@ -208,15 +232,20 @@ class ErrorsAndWarnings(IErrorsAndWarnings):
                                       is_system=is_system,
                                       is_removed=is_removed)
         return [e.message for e in u_file.errors
-                if e.severity is Error.Severity.WARNING]
+                if e.severity is Severity.WARNING]
 
     def _get_warnings(self, is_active: Optional[bool] = None) -> List[Error]:
-        return (
-            [error for u_file in self.__api.files
-             for error in u_file.errors
-             if error.severity is Error.Severity.WARNING
-             and (is_active is None or u_file.is_active == is_active)]
-            +
-            [error for error in self._errors
-             if error.severity is Error.Severity.WARNING]
-        )
+        return self._get_warnings_file(is_active) + self._warnings
+
+    def _get_warnings_file(self, is_active: Optional[bool]) -> List[Error]:
+        return [e for u_file in self.__api.files for e in u_file.errors
+                if e.is_warning
+                and (is_active is None or u_file.is_active == is_active)]
+
+    def _insert_error(self, error: Error) -> None:
+        # pylint doesn't know that dataclasses is initializing this with a
+        # dict.
+        self._errors[(error.path, error.code)] = error  # pylint: disable=unsupported-assignment-operation
+
+    def _remove_error(self, code: Code, path: Optional[str] = None) -> None:
+        self._errors.pop((path, code), None)

--- a/filemanager/domain/uploads/errors_and_warnings.py
+++ b/filemanager/domain/uploads/errors_and_warnings.py
@@ -73,6 +73,12 @@ class IErrorsAndWarnings(Protocol):
                              is_persistant: bool = False) -> None:
         """Add a warning for the workspace that is not specific to a file."""
 
+    def get_errors(self, path: str,
+                   is_ancillary: bool = False,
+                   is_system: bool = False,
+                   is_removed: bool = False) -> List[str]:
+        """Get all errors for the file at ``path``."""
+
     def get_warnings(self, path: str,
                      is_ancillary: bool = False,
                      is_system: bool = False,
@@ -223,6 +229,16 @@ class ErrorsAndWarnings(IErrorsAndWarnings):
         self.add_error_non_file(code, msg, severity=Severity.WARNING,
                                 is_persistant=is_persistant)
 
+    def get_errors(self, path: str,
+                   is_ancillary: bool = False,
+                   is_system: bool = False,
+                   is_removed: bool = False) -> List[str]:
+        """Get all errors for the file at ``path``."""
+        u_file = self.__api.files.get(path, is_ancillary=is_ancillary,
+                                      is_system=is_system,
+                                      is_removed=is_removed)
+        return [e.message for e in u_file.errors]
+
     def get_warnings(self, path: str,
                      is_ancillary: bool = False,
                      is_system: bool = False,
@@ -231,8 +247,7 @@ class ErrorsAndWarnings(IErrorsAndWarnings):
         u_file = self.__api.files.get(path, is_ancillary=is_ancillary,
                                       is_system=is_system,
                                       is_removed=is_removed)
-        return [e.message for e in u_file.errors
-                if e.severity is Severity.WARNING]
+        return [e.message for e in u_file.errors if e.is_warning]
 
     def _get_warnings(self, is_active: Optional[bool] = None) -> List[Error]:
         return self._get_warnings_file(is_active) + self._warnings

--- a/filemanager/domain/uploads/errors_and_warnings.py
+++ b/filemanager/domain/uploads/errors_and_warnings.py
@@ -207,7 +207,7 @@ class ErrorsAndWarnings(IErrorsAndWarnings):
         if path is None:
             self._remove_error(code, path)
         else:
-            self.__api.get(path).remove_error(code)
+            self.__api.files.get(path).remove_error(code)
 
 
     def add_error_non_file(self, code: Code, msg: str,

--- a/filemanager/domain/uploads/file_mutations.py
+++ b/filemanager/domain/uploads/file_mutations.py
@@ -16,7 +16,7 @@ from typing_extensions import Protocol
 from ..index import FileIndex
 
 from ..uploaded_file import UserFile
-from ..error import Error, Severity
+from ..error import Error, Severity, Code
 from ..file_type import FileType
 
 from .base import IStorageAdapter, IBaseWorkspace
@@ -31,7 +31,7 @@ class IWorkspace(IBaseWorkspace, Protocol):
     implementation by other components of the workspace.
     """
 
-    def add_error(self, u_file: UserFile, msg: str,
+    def add_error(self, u_file: UserFile, code: Code, msg: str,
                   severity: Severity = Severity.FATAL,
                   is_persistant: bool = True) -> None:
         """Add an error for a specific file."""
@@ -306,20 +306,17 @@ class FileMutations(IFileMutations):
         self.__api.storage.remove(self, u_file)
 
         if u_file.is_directory:
-            for former_path, _file \
-                    in self.__api.iter_children(u_file):
+            for _, _file in self.__api.iter_children(u_file):
                 _file.is_removed = True
-                self.drop_refs(_file.path,
-                                              is_ancillary=_file.is_ancillary,
-                                              is_removed=False,
-                                              is_system=_file.is_system)
+                self.drop_refs(_file.path, is_ancillary=_file.is_ancillary,
+                               is_removed=False, is_system=_file.is_system)
                 self.__api.files.set(_file.path, _file)
 
         u_file.is_removed = True
         u_file.reason_for_removal = reason
 
-        self.__api.add_error(u_file, reason, severity=Severity.INFO,
-                             is_persistant=False)
+        # self.__api.add_error(u_file, reason, severity=Severity.INFO,
+        #                      is_persistant=False)
 
         self.drop_refs(u_file.path, is_ancillary=u_file.is_ancillary,
                              is_removed=False,

--- a/filemanager/domain/uploads/file_mutations.py
+++ b/filemanager/domain/uploads/file_mutations.py
@@ -16,7 +16,7 @@ from typing_extensions import Protocol
 from ..index import FileIndex
 
 from ..uploaded_file import UserFile
-from ..error import Error
+from ..error import Error, Severity
 from ..file_type import FileType
 
 from .base import IStorageAdapter, IBaseWorkspace
@@ -32,7 +32,7 @@ class IWorkspace(IBaseWorkspace, Protocol):
     """
 
     def add_error(self, u_file: UserFile, msg: str,
-                  severity: Error.Severity = Error.Severity.FATAL,
+                  severity: Severity = Severity.FATAL,
                   is_persistant: bool = True) -> None:
         """Add an error for a specific file."""
 
@@ -318,7 +318,7 @@ class FileMutations(IFileMutations):
         u_file.is_removed = True
         u_file.reason_for_removal = reason
 
-        self.__api.add_error(u_file, reason, severity=Error.Severity.INFO,
+        self.__api.add_error(u_file, reason, severity=Severity.INFO,
                              is_persistant=False)
 
         self.drop_refs(u_file.path, is_ancillary=u_file.is_ancillary,

--- a/filemanager/domain/uploads/tests/test_errors_and_warnings.py
+++ b/filemanager/domain/uploads/tests/test_errors_and_warnings.py
@@ -1,0 +1,100 @@
+"""Tests for :mod:`.uploads.errors_and_warnings`."""
+
+from unittest import TestCase, mock
+
+from ...uploads import FileIndex
+from ...uploaded_file import UserFile
+from ...error import Error, Code, Severity
+from ..errors_and_warnings import ErrorsAndWarnings, IWorkspace
+
+
+class AddErrors(TestCase):
+    """Test adding errors."""
+
+    def test_add_error_file(self):
+        """Add a fatal error for a file."""
+        api = mock.MagicMock(spec=IWorkspace, files=FileIndex())
+        u_file = UserFile(api, 'foo/path', 42)
+        api.files.set(u_file.path, u_file)
+        eaw = ErrorsAndWarnings()
+        eaw.__api_init__(api)
+        eaw.add_error(u_file, 'foo_error', 'this is a foo error')
+
+        self.assertTrue(eaw.has_errors)
+        self.assertTrue(eaw.has_errors_fatal)
+        self.assertEqual(len(eaw.errors), 1)
+
+    def test_add_duplicate_error_file(self):
+        """Add two fatal errors for a file with the same code."""
+        api = mock.MagicMock(spec=IWorkspace, files=FileIndex())
+        u_file = UserFile(api, 'foo/path', 42)
+        api.files.set(u_file.path, u_file)
+        eaw = ErrorsAndWarnings()
+        eaw.__api_init__(api)
+        eaw.add_error(u_file, 'foo_error', 'this is a foo error')
+        eaw.add_error(u_file, 'foo_error', 'this is also a foo error')
+
+        self.assertTrue(eaw.has_errors)
+        self.assertTrue(eaw.has_errors_fatal)
+        self.assertEqual(len(eaw.errors), 1, 'Only one error per code')
+
+        eaw.add_error(u_file, 'baz_error', 'this is not a foo error')
+        self.assertEqual(len(eaw.errors), 2)
+
+    def test_remove_error_file(self):
+        """Remove an error for a file."""
+        api = mock.MagicMock(spec=IWorkspace, files=FileIndex())
+        u_file = UserFile(api, 'foo/path', 42)
+        api.files.set(u_file.path, u_file)
+        eaw = ErrorsAndWarnings()
+        eaw.__api_init__(api)
+        eaw.add_error(u_file, 'foo_error', 'this is a foo error')
+        eaw.add_error(u_file, 'foo_error', 'this is also a foo error')
+
+        self.assertTrue(eaw.has_errors)
+        self.assertTrue(eaw.has_errors_fatal)
+        self.assertEqual(len(eaw.errors), 1, 'Only one error per code')
+
+        eaw.remove_error('foo_error', u_file.path)
+        self.assertEqual(len(eaw.errors), 0)
+        self.assertFalse(eaw.has_errors)
+        self.assertFalse(eaw.has_errors_fatal)
+
+    def test_add_error_file_to_file(self):
+        """Add an error for a file to the file itself."""
+        api = mock.MagicMock(spec=IWorkspace, files=FileIndex())
+        u_file = UserFile(api, 'foo/path', 42)
+        api.files.set(u_file.path, u_file)
+        eaw = ErrorsAndWarnings()
+        eaw.__api_init__(api)
+        u_file.add_error(Error(severity=Severity.FATAL,
+                               code='foo_error',
+                               message='this is a foo error'))
+
+        self.assertTrue(eaw.has_errors)
+        self.assertTrue(eaw.has_errors_fatal)
+        self.assertEqual(len(eaw.errors), 1)
+
+    def test_remove_error_file_from_file(self):
+        """Remove an error for a file from the file itself."""
+        api = mock.MagicMock(spec=IWorkspace, files=FileIndex())
+        u_file = UserFile(api, 'foo/path', 42)
+        api.files.set(u_file.path, u_file)
+        eaw = ErrorsAndWarnings()
+        eaw.__api_init__(api)
+        eaw.add_error(u_file, 'foo_error', 'this is a foo error')
+        eaw.add_error(u_file, 'foo_error', 'this is also a foo error')
+
+        self.assertTrue(eaw.has_errors)
+        self.assertTrue(eaw.has_errors_fatal)
+        self.assertEqual(len(eaw.errors), 1, 'Only one error per code')
+
+        # Remove an error directly from the file.
+        u_file.remove_error('foo_error')
+        self.assertEqual(len(eaw.errors), 0)
+        self.assertFalse(eaw.has_errors)
+        self.assertFalse(eaw.has_errors_fatal)
+
+
+
+

--- a/filemanager/process/check/errata.py
+++ b/filemanager/process/check/errata.py
@@ -4,10 +4,13 @@ import os
 import re
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace, Code
+from ...domain import FileType, UserFile, Workspace, Code, Severity
 from .base import BaseChecker
 
 logger = logging.getLogger(__name__)
+
+DISALLOWED_FILE: Code = 'disallowed_file'
+DISALLOWED_FILE_MESSAGE = "Removed file '%s' [File not allowed]."
 
 
 class RemoveHyperlinkStyleFiles(BaseChecker):
@@ -23,14 +26,23 @@ class RemoveHyperlinkStyleFiles(BaseChecker):
     DOT_TEX_DETECTED: Code = 'dot_tex_detected'
     DOT_TEX_MESSAGE = "Possible submitter error. Unwanted '%s'"
 
-    WARNING_MSG = ("Found hyperlink-compatible package '%s'. Will remove and"
-                   " use hypertex-compatible local version")
+    HYPERLINK_COMPATIBLE: Code = 'hyperlink_compatible_package'
+    HYPERLINK_COMPATIBLE_MESSAGE = (
+        "Found hyperlink-compatible package '%s'. Will remove and use"
+        " hypertex-compatible local version"
+    )
 
     def check(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Check for and remove hyperlink styles espcrc2 and lamuphys."""
         if self.DOT_STY.search(u_file.name):
-            workspace.remove(u_file, self.WARNING_MSG % u_file.name)
+            workspace.add_error(
+                u_file, self.HYPERLINK_COMPATIBLE,
+                self.HYPERLINK_COMPATIBLE_MESSAGE % u_file.name,
+                severity=Severity.INFO, is_persistant=False
+            )
+            workspace.remove(u_file,
+                             self.HYPERLINK_COMPATIBLE_MESSAGE % u_file.name)
 
         elif self.DOT_TEX.search(u_file.name):
             # I'm not sure why this is just a warning
@@ -50,9 +62,10 @@ class RemoveDisallowedFiles(BaseChecker):
             -> UserFile:
         """Check for and removes disallowed files."""
         if u_file.name in self.DISALLOWED:
-            workspace.remove(u_file,
-                             f"Removed file '{u_file.name}' [File not"
-                             " allowed].")
+            workspace.add_error(u_file, DISALLOWED_FILE,
+                                DISALLOWED_FILE_MESSAGE % u_file.name,
+                                severity=Severity.INFO, is_persistant=False)
+            workspace.remove(u_file, DISALLOWED_FILE_MESSAGE % u_file.name)
         return u_file
 
 
@@ -69,9 +82,11 @@ class RemoveMetaFiles(BaseChecker):
         """Check for and remove disallowed meta files."""
         for pattern in self.DISALLOWED_PATTERNS:
             if pattern.search(u_file.name):
-                workspace.remove(u_file,
-                                 f"Removed file '{u_file.name}' [File not"
-                                 " allowed].")
+                workspace.add_error(u_file, DISALLOWED_FILE,
+                                    DISALLOWED_FILE_MESSAGE % u_file.name,
+                                    severity=Severity.INFO,
+                                    is_persistant=False)
+                workspace.remove(u_file, DISALLOWED_FILE_MESSAGE % u_file.name)
         return u_file
 
 
@@ -94,6 +109,9 @@ class RemoveExtraneousRevTeXFiles(BaseChecker):
             -> UserFile:
         """Check for and remove files already included in TeX Live release."""
         if self.EXTRANEOUS.search(u_file.name):
+            workspace.add_error(u_file, DISALLOWED_FILE,
+                                self.REVTEX_WARNING_MSG,
+                                severity=Severity.INFO, is_persistant=False)
             workspace.remove(u_file, self.REVTEX_WARNING_MSG)
         return u_file
 
@@ -120,6 +138,8 @@ class RemoveDiagramsPackage(BaseChecker):
             -> UserFile:
         """Check for and remove the diagrams package."""
         if self.DIAGRAMS.search(u_file.name):
+            workspace.add_error(u_file, DISALLOWED_FILE, self.DIAGRAMS_WARNING,
+                                severity=Severity.INFO, is_persistant=False)
             workspace.remove(u_file, self.DIAGRAMS_WARNING)
         return u_file
 
@@ -141,6 +161,8 @@ class RemoveAADemoFile(BaseChecker):
             -> UserFile:
         """Check for and remove the ``aa.dem`` file."""
         if u_file.name == 'aa.dem':
+            workspace.add_error(u_file, DISALLOWED_FILE, self.AA_DEM_MSG,
+                                severity=Severity.INFO, is_persistant=False)
             workspace.remove(u_file, self.AA_DEM_MSG)
         return u_file
 
@@ -161,6 +183,8 @@ class RemoveMissingFontFile(BaseChecker):
             -> UserFile:
         """Check for and remove the ``missfont.log`` file."""
         if u_file.name == 'missfont.log':
+            workspace.add_error(u_file, DISALLOWED_FILE, self.MISSFONT_WARNING,
+                                severity=Severity.INFO, is_persistant=False)
             workspace.remove(u_file, self.MISSFONT_WARNING)
         return u_file
 
@@ -183,6 +207,9 @@ class RemoveSyncTeXFiles(BaseChecker):
             -> UserFile:
         """Check for and remove synctex files."""
         if self.SYNCTEX.search(u_file.name):
+            workspace.add_error(u_file, DISALLOWED_FILE,
+                                self.SYNCTEX_MSG % u_file.name,
+                                severity=Severity.INFO, is_persistant=False)
             workspace.remove(u_file, self.SYNCTEX_MSG % u_file.name)
         return u_file
 

--- a/filemanager/process/check/file_extensions.py
+++ b/filemanager/process/check/file_extensions.py
@@ -4,7 +4,7 @@ import os
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker
 
 
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 class FixFileExtensions(BaseChecker):
     """Checks and fixes filename extensions for known formats."""
 
+    FIXED_EXTENSION: Code = 'fixed_extension'
+    FIXED_EXTENSION_MESSAGE = "Renamed '%s' to '%s'."
+
     def _change_extension(self, workspace: Workspace,
                           u_file: UserFile, extension: str) \
             -> UserFile:
@@ -22,8 +25,11 @@ class FixFileExtensions(BaseChecker):
         base_name, _ = os.path.splitext(name)
         new_name = f'{base_name}.{extension}'
         workspace.rename(u_file, os.path.join(base_dir, new_name))
-        workspace.add_warning(u_file, f"Renamed '{prev_name}' to {new_name}.",
-                              is_persistant=False)
+        workspace.add_warning(
+            u_file, self.FIXED_EXTENSION,
+            self.FIXED_EXTENSION_MESSAGE % (prev_name, new_name),
+            is_persistant=False
+        )
         return u_file
 
     def check_POSTSCRIPT(self, workspace: Workspace,

--- a/filemanager/process/check/hidden_files.py
+++ b/filemanager/process/check/hidden_files.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker
 
 
@@ -17,11 +17,15 @@ logger = logging.getLogger(__name__)
 class RemoveMacOSXHiddenFiles(BaseChecker):
     """Removes ``__MACOSX`` directories."""
 
+    HIDDEN_FILES_MACOSX: Code = 'hidden_files'
+    HIDDEN_FILES_MACOSX_MESSAGE = "Removed '__MACOSX' directory."
+
     def check(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Remove ``__MACOSX`` directories."""
         if u_file.is_directory and u_file.name.strip('/') == '__MACOSX':
-            workspace.add_warning(u_file, "Removed '__MACOSX' directory.",
+            workspace.add_warning(u_file, self.HIDDEN_FILES_MACOSX,
+                                  self.HIDDEN_FILES_MACOSX_MESSAGE,
                                   is_persistant=False)
             workspace.remove(u_file)
         return u_file
@@ -30,11 +34,15 @@ class RemoveMacOSXHiddenFiles(BaseChecker):
 class RemoveFilesWithLeadingDot(BaseChecker):
     """Removes files and directories that start with a dot."""
 
+    HIDDEN_FILES_DOT = 'hidden_files_dot'
+    HIDDEN_FILES_MESSAGE = 'Hidden file are not allowed.'
+
     def check(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Removes files and directories that start with a dot."""
         if u_file.name.startswith('.') or u_file.path.startswith('.'):
-            workspace.add_warning(u_file, 'Hidden file are not allowed.',
+            workspace.add_warning(u_file, self.HIDDEN_FILES_DOT,
+                                  self.HIDDEN_FILES_MESSAGE,
                                   is_persistant=False)
             workspace.remove(u_file,
                              f"Removed file '{u_file.name}' [File not"

--- a/filemanager/process/check/hidden_files.py
+++ b/filemanager/process/check/hidden_files.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace, Code
+from ...domain import FileType, UserFile, Workspace, Code, Severity
 from .base import BaseChecker
 
 
@@ -41,9 +41,9 @@ class RemoveFilesWithLeadingDot(BaseChecker):
             -> UserFile:
         """Removes files and directories that start with a dot."""
         if u_file.name.startswith('.') or u_file.path.startswith('.'):
-            workspace.add_warning(u_file, self.HIDDEN_FILES_DOT,
-                                  self.HIDDEN_FILES_MESSAGE,
-                                  is_persistant=False)
+            workspace.add_error(u_file, self.HIDDEN_FILES_DOT,
+                                self.HIDDEN_FILES_MESSAGE,
+                                severity=Severity.INFO, is_persistant=False)
             workspace.remove(u_file,
                              f"Removed file '{u_file.name}' [File not"
                              " allowed].")

--- a/filemanager/process/check/images.py
+++ b/filemanager/process/check/images.py
@@ -4,7 +4,7 @@ import os
 import re
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,8 @@ class CheckForUnacceptableImages(BaseChecker):
     """
 
     UNACCEPTABLE = re.compile(r'\.(pcx|bmp|wmf|opj|pct|tiff?)$', re.IGNORECASE)
-    ERROR_MSG = (
+    UNSUPPORTED_IMAGE: Code = 'unsupported_image'
+    UNSUPPORTED_IMAGE_MESSAGE = (
         f"%s is not a supported graphics format: most "
         "readers do not have the programs needed to view and print "
         ".$format figures. Please save your [% format %] "
@@ -35,5 +36,9 @@ class CheckForUnacceptableImages(BaseChecker):
         """Check and warn about image types that are not accepted."""
         match = self.UNACCEPTABLE.search(u_file.name)
         if match:
-            workspace.add_warning(u_file, self.ERROR_MSG % match.group(1))
+            workspace.add_warning(
+                u_file,
+                self.UNSUPPORTED_IMAGE,
+                self.UNSUPPORTED_IMAGE_MESSAGE % match.group(1)
+            )
         return u_file

--- a/filemanager/process/check/invalid_types.py
+++ b/filemanager/process/check/invalid_types.py
@@ -2,7 +2,7 @@
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace, SourceType
+from ...domain import FileType, UserFile, Workspace, SourceType, Code
 from .base import BaseChecker
 
 
@@ -12,22 +12,26 @@ logger = logging.getLogger(__name__)
 class FlagInvalidSourceTypes(BaseChecker):
     """Flag any invalid source types."""
 
-    DOCX_ERROR_MESSAGE = (
+    DOCX_NOT_SUPPORTED: Code = 'docx_not_supported'
+    DOCX_MESSAGE = (
         "Submissions in docx are no longer supported. Please create a PDF file"
         " and submit that instead. Server side conversion of .docx to PDF may"
         " lead to incorrect font substitutions, among other problems, and your"
         " own PDF is likely to be more accurate."
     )
 
-    ODF_ERROR_MESSAGE = (
+    ODF_NOT_SUPPORTED: Code = 'odf_not_supported'
+    ODF_MESSAGE = (
         "Unfortunately arXiv does not support ODF. Please submit PDF instead."
     )
 
-    EPS_ERROR_MESSAGE = (
+    EPS_NOT_SUPPORTED: Code = 'eps_not_supported'
+    EPS_MESSAGE = (
         "This file appears to be a single encapsulated PostScript file."
     )
 
-    TEXAUX_ERROR_MESSAGE = (
+    SINGLE_AUX_TEX: Code = 'single_auxiliary_tex_file'
+    SINGLE_AUX_TEX_MESSAGE = (
         "This file appears to be a single auxiliary TeX file."
     )
 
@@ -36,7 +40,8 @@ class FlagInvalidSourceTypes(BaseChecker):
         """We no longer support DOCX."""
         if workspace.file_count == 1:
             workspace.source_type = SourceType.INVALID
-            workspace.add_error(u_file, self.DOCX_ERROR_MESSAGE)
+            workspace.add_error(u_file, self.DOCX_NOT_SUPPORTED,
+                                self.DOCX_MESSAGE)
         return u_file
 
     def check_ODF(self, workspace: Workspace, u_file: UserFile) \
@@ -44,7 +49,8 @@ class FlagInvalidSourceTypes(BaseChecker):
         """We no longer support ODF."""
         if workspace.file_count == 1:
             workspace.source_type = SourceType.INVALID
-            workspace.add_error(u_file, self.DOCX_ERROR_MESSAGE)
+            workspace.add_error(u_file, self.ODF_NOT_SUPPORTED,
+                                self.ODF_MESSAGE)
         return u_file
 
     def check_EPS(self, workspace: Workspace, u_file: UserFile) \
@@ -52,7 +58,8 @@ class FlagInvalidSourceTypes(BaseChecker):
         """Encapsulated postscript format is not supported."""
         if workspace.file_count == 1:
             workspace.source_type = SourceType.INVALID
-            workspace.add_error(u_file, self.EPS_ERROR_MESSAGE)
+            workspace.add_error(u_file, self.EPS_NOT_SUPPORTED,
+                                self.EPS_MESSAGE)
         return u_file
 
     def check_TEXAUX(self, workspace: Workspace, u_file: UserFile) \
@@ -60,17 +67,20 @@ class FlagInvalidSourceTypes(BaseChecker):
         """Auxiliary TeX files are not allowed."""
         if workspace.file_count == 1:
             workspace.source_type = SourceType.INVALID
-            workspace.add_error(u_file, self.TEXAUX_ERROR_MESSAGE)
+            workspace.add_error(u_file, self.SINGLE_AUX_TEX,
+                                self.SINGLE_AUX_TEX_MESSAGE)
         return u_file
 
 
 class FlagInvalidFileTypes(BaseChecker):
     """Flag any invalid file types."""
 
+    RAR_NOT_SUPPORTED: Code = 'rar_not_supported'
+    RAR_MESSAGE = ("We do not support 'rar' files. Please use 'zip' or 'tar' "
+                   "instead.")
+
     def check_RAR(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Disallow rar files."""
-        workspace.add_error(u_file,
-                            "We do not support 'rar' files. Please use 'zip'"
-                            " or 'tar' instead.")
+        workspace.add_error(u_file, self.RAR_NOT_SUPPORTED, self.RAR_MESSAGE)
         return u_file

--- a/filemanager/process/check/missing_references.py
+++ b/filemanager/process/check/missing_references.py
@@ -4,7 +4,7 @@ import os
 import re
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker
 
 logger = logging.getLogger(__name__)
@@ -20,14 +20,16 @@ class CheckForMissingReferences(BaseChecker):
 
     BIB_FILE = re.compile(r'(.*)\.bib$', re.IGNORECASE)
 
-    BIB_WITH_BBL_WARNING = (
+    BIB_WITH_BBL: Code = 'bib_with_bbl'
+    BIB_WITH_BBL_MESSAGE = (
         "We do not run bibtex in the auto - TeXing procedure. We do not run"
         " bibtex because the .bib database files can be quite large, and the"
         " only thing necessary to make the references for a given paper is"
         " the .bbl file."
     )
 
-    BIB_NO_BBL_WARNING = (
+    BIB_NO_BBL: Code = 'bib_no_bbl'
+    BIB_NO_BBL_MESSAGE = (
         "We do not run bibtex in the auto - TeXing "
         "procedure. If you use it, include in your submission the .bbl file "
         "which bibtex produces on your home machine; otherwise your "
@@ -37,7 +39,8 @@ class CheckForMissingReferences(BaseChecker):
         "the.bbl file."
     )
 
-    BBL_MISSING_MSG = (
+    BBL_MISSING: Code = 'bbl_missing'
+    BBL_MISSING_MESSAGE = (
         "Your submission contained {base}.bib file, but no {base}.bbl"
         " file (include {base}.bbl, or submit without {base}.bib; and"
         " remember to verify references)."
@@ -67,7 +70,8 @@ class CheckForMissingReferences(BaseChecker):
         if workspace.exists(bbl_path):
             # If .bbl exists we go ahead and delete .bib file and warn
             # submitter of this action.
-            workspace.add_warning(u_file, self.BIB_WITH_BBL_WARNING,
+            workspace.add_warning(u_file, self.BIB_WITH_BBL,
+                                  self.BIB_WITH_BBL_MESSAGE,
                                   is_persistant=False)
             workspace.remove(u_file,
                              f"Removed the file '{u_file.name}'. Using"
@@ -76,6 +80,7 @@ class CheckForMissingReferences(BaseChecker):
             # Missing .bbl (potential missing references). Generate an
             # error and DO NOT DELETE .bib file. Note: We are using .bib as
             # flag until .bbl exists.
-            workspace.add_warning(u_file, self.BIB_NO_BBL_WARNING)
-            workspace.add_error(u_file,
-                                self.BBL_MISSING_MSG.format(base=base))
+            workspace.add_warning(u_file, self.BIB_NO_BBL,
+                                  self.BIB_NO_BBL_MESSAGE)
+            workspace.add_error(u_file, self.BBL_MISSING,
+                                self.BBL_MISSING_MESSAGE.format(base=base))

--- a/filemanager/process/check/processed.py
+++ b/filemanager/process/check/processed.py
@@ -22,7 +22,7 @@ from typing import Callable, Optional
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker
 
 
@@ -32,10 +32,13 @@ logger = logging.getLogger(__name__)
 class WarnAboutProcessedDirectory(BaseChecker):
     """Check for and warn about processed directory."""
 
+    PROCESSED_DIRECTORY: Code = 'processed_directory'
+    PROCESSED_DIRECTORY_MESSAGE = \
+        "Detected 'processed' directory. Please check."
+
     def check(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         if u_file.is_directory and u_file.name.strip('/') == 'processed':
-            workspace.add_warning(u_file,
-                                  "Detected 'processed' directory. Please"
-                                  " check.")
+            workspace.add_warning(u_file, self.PROCESSED_DIRECTORY,
+                                  self.PROCESSED_DIRECTORY_MESSAGE)
         return u_file

--- a/filemanager/process/check/source_types.py
+++ b/filemanager/process/check/source_types.py
@@ -42,10 +42,6 @@ class InferSourceType(BaseChecker):
 
     def check_workspace(self, workspace: Workspace) -> None:
         """Determine the source type for the workspace as a whole."""
-        logger.debug('Check whole workspace')
-        # if not workspace.source_type.is_unknown:
-        #     return
-
         if workspace.file_count == 0:
             # No files detected, were all files removed? did user clear out
             # files? Since users are allowed to remove all files we won't
@@ -56,8 +52,6 @@ class InferSourceType(BaseChecker):
             return
 
         if not workspace.source_type.is_unknown:
-            logger.debug('Source type already identified as %s',
-                         workspace.source_type)
             return
 
         type_counts = workspace.get_file_type_counts()
@@ -84,22 +78,24 @@ class InferSourceType(BaseChecker):
         elif type_counts['all_files'] > 0 and type_counts['files'] == 0:
             # No source files detected, extra ancillary files may be present
             # User may have deleted main document source.
-            logger.debug('No active (non-ancillary) submission files')
             workspace.source_type = SourceType.INVALID
         elif type_counts[FileType.HTML] > 0 \
                 and type_counts['files'] == html_aux_file_count:
+            workspace.remove_error(INVALID_SOURCE_TYPE)
             workspace.source_type = SourceType.HTML
         elif type_counts[FileType.POSTSCRIPT] > 0 \
                 and type_counts['files'] == postscript_aux_file_counts:
+            workspace.remove_error(INVALID_SOURCE_TYPE)
             workspace.source_type = SourceType.POSTSCRIPT
         else:   # Default source type is TEX
-            logger.debug('Default source type is TeX')
+            workspace.remove_error(INVALID_SOURCE_TYPE)
             workspace.source_type = SourceType.TEX
 
     def check_tex_types(self, workspace: Workspace,
                         u_file: UserFile) -> UserFile:
         """Check for single-file TeX source package."""
         if workspace.source_type.is_unknown and workspace.file_count == 1:
+            workspace.remove_error(INVALID_SOURCE_TYPE)
             workspace.source_type = SourceType.TEX
         return u_file
 
@@ -107,6 +103,7 @@ class InferSourceType(BaseChecker):
                          u_file: UserFile) -> UserFile:
         """Check for single-file PostScript source package."""
         if workspace.source_type.is_unknown and workspace.file_count == 1:
+            workspace.remove_error(INVALID_SOURCE_TYPE)
             workspace.source_type = SourceType.POSTSCRIPT
         return u_file
 
@@ -123,6 +120,7 @@ class InferSourceType(BaseChecker):
             -> UserFile:
         """Check for single-file HTML source package."""
         if workspace.source_type.is_unknown and workspace.file_count == 1:
+            workspace.remove_error(INVALID_SOURCE_TYPE)
             workspace.source_type = SourceType.HTML
         return u_file
 

--- a/filemanager/process/check/source_types.py
+++ b/filemanager/process/check/source_types.py
@@ -110,7 +110,6 @@ class InferSourceType(BaseChecker):
     def check_PDF(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Check for single-file PDF source package."""
-        logger.debug('Check PDF?')
         if workspace.file_count == 1:
             workspace.remove_error(INVALID_SOURCE_TYPE)
             workspace.source_type = SourceType.PDF
@@ -129,8 +128,8 @@ class InferSourceType(BaseChecker):
         """Check for single-file source with failed type detection."""
         if workspace.source_type.is_unknown and workspace.file_count == 1:
             workspace.source_type = SourceType.INVALID
-            workspace.add_error(u_file, INVALID_SOURCE_TYPE,
-                                self.SINGLE_FILE_UNKNOWN_MESSAGE)
+            workspace.add_error_non_file(INVALID_SOURCE_TYPE,
+                                         self.SINGLE_FILE_UNKNOWN_MESSAGE)
         return u_file
 
     # def check_DOS_EPS(self, workspace: Workspace, u_file: UserFile) \
@@ -146,6 +145,6 @@ class InferSourceType(BaseChecker):
         if workspace.source_type.is_unknown and workspace.file_count == 1:
             logger.debug('Source type not known, and only one file')
             workspace.source_type = SourceType.INVALID
-            workspace.add_error(u_file, INVALID_SOURCE_TYPE,
-                                self.UNSUPPORTED_MESSAGE)
+            workspace.add_error_non_file(INVALID_SOURCE_TYPE,
+                                         self.UNSUPPORTED_MESSAGE)
         return u_file

--- a/filemanager/process/check/tex_generated.py
+++ b/filemanager/process/check/tex_generated.py
@@ -4,7 +4,7 @@ import os
 import re
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker
 
 logger = logging.getLogger(__name__)
@@ -46,12 +46,14 @@ class DisallowDVIFiles(BaseChecker):
     was also included???????
     """
 
-    ERROR_MSG = ('%s is a TeX-produced DVI file. Please submit the TeX source'
-                 ' instead.')
+    DVI_NOT_ALLOWED: Code
+    DVI_MESSAGE = ('%s is a TeX-produced DVI file. Please submit the TeX'
+                   'source instead.')
 
     def check_DVI(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Add an error for any non-ancillary DVI file."""
         if not u_file.is_ancillary:
-            workspace.add_error(u_file, self.ERROR_MSG % u_file.name)
+            workspace.add_error(u_file, self.DVI_NOT_ALLOWED,
+                                self.DVI_MESSAGE % u_file.name)
         return u_file

--- a/filemanager/process/check/top_level_directory.py
+++ b/filemanager/process/check/top_level_directory.py
@@ -4,7 +4,7 @@ import os
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker, StopCheck
 
 
@@ -20,6 +20,9 @@ class RemoveTopLevelDirectory(BaseChecker):
     files in a subdirectory.
     """
 
+    TOP_LEVEL_DIRECTORY: Code = 'top_level_directory_removed'
+    TOP_LEVEL_DIRECTORY_MESSAGE = "Removed top level directory"
+
     def check_workspace(self, workspace: Workspace) -> None:
         """Eliminate single top-level directory."""
         # source_directory = self.source_path
@@ -33,7 +36,8 @@ class RemoveTopLevelDirectory(BaseChecker):
         if len(entries) == 1 \
                 and entries[0].is_directory and not entries[0].is_ancillary:
 
-            workspace.add_warning(entries[0], "Removed top level directory",
+            workspace.add_warning(entries[0], self.TOP_LEVEL_DIRECTORY,
+                                  self.TOP_LEVEL_DIRECTORY_MESSAGE,
                                   is_persistant=False)
             for _, child in workspace.iter_children(entries[0], max_depth=1):
                 _, new_path = child.path.split(entries[0].path, 1)

--- a/filemanager/process/check/unpack.py
+++ b/filemanager/process/check/unpack.py
@@ -15,7 +15,7 @@ logger.propagate = False
 
 UNPACK_ERROR: Code = "unpack_error"
 UNPACK_ERROR_MESSAGE = ("There were problems unpacking '%s'. Please try "
-                        "again and confirm your files.")
+                        "again and confirm your files. Error: %s")
 
 DISALLOWED_FILES: Code = "contains_disallowed_files"
 DISALLOWED_MESSAGE = "%s are not allowed. Removing '%s'"
@@ -107,11 +107,11 @@ class UnpackCompressedTarFiles(BaseChecker):
                                  is_ancillary=is_ancillary)
         return u_file
 
-    def _unpack(self, workspace: Workspace, u_file: UserFile) \
-            -> UserFile:
+    def _unpack(self, workspace: Workspace, u_file: UserFile) -> UserFile:
         if not workspace.is_tarfile(u_file):
             workspace.add_error(u_file, self.UNREADABLE_TAR,
-                                self.UNREADABLE_TAR_MESSAGE % u_file.name)
+                                self.UNREADABLE_TAR_MESSAGE %
+                                (u_file.name, 'not a tar file'))
             return u_file
 
         workspace.log.info(

--- a/filemanager/process/check/zero_length_files.py
+++ b/filemanager/process/check/zero_length_files.py
@@ -4,7 +4,7 @@ import os
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace
+from ...domain import FileType, UserFile, Workspace, Code
 from .base import BaseChecker
 
 
@@ -14,13 +14,15 @@ logger = logging.getLogger(__name__)
 class ZeroLengthFileChecker(BaseChecker):
     """Checks for and removes zero-length files."""
 
-    ZERO_LENGTH_MSG = f"File '%s' is empty (size is zero)."
+    ZERO_LENGTH: Code = 'zero_length'
+    ZERO_LENGTH_MESSAGE = "File '%s' is empty (size is zero)."
 
     def check(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Determine wether a file is zero-length, and remove it if so."""
         if u_file.is_empty and not u_file.is_directory:
-            workspace.add_warning(u_file, self.ZERO_LENGTH_MSG % u_file.name,
+            workspace.add_warning(u_file, self.ZERO_LENGTH,
+                                  self.ZERO_LENGTH_MESSAGE % u_file.name,
                                   is_persistant=False)
             workspace.remove(u_file,
                              f"Removed file '{u_file.name}' [file is empty].")

--- a/filemanager/process/check/zero_length_files.py
+++ b/filemanager/process/check/zero_length_files.py
@@ -4,7 +4,7 @@ import os
 
 from arxiv.base import logging
 
-from ...domain import FileType, UserFile, Workspace, Code
+from ...domain import FileType, UserFile, Workspace, Code, Severity
 from .base import BaseChecker
 
 
@@ -15,15 +15,14 @@ class ZeroLengthFileChecker(BaseChecker):
     """Checks for and removes zero-length files."""
 
     ZERO_LENGTH: Code = 'zero_length'
-    ZERO_LENGTH_MESSAGE = "File '%s' is empty (size is zero)."
+    ZERO_LENGTH_MESSAGE = "Removed file '%s' [file is empty]."
 
     def check(self, workspace: Workspace, u_file: UserFile) \
             -> UserFile:
         """Determine wether a file is zero-length, and remove it if so."""
         if u_file.is_empty and not u_file.is_directory:
-            workspace.add_warning(u_file, self.ZERO_LENGTH,
-                                  self.ZERO_LENGTH_MESSAGE % u_file.name,
-                                  is_persistant=False)
-            workspace.remove(u_file,
-                             f"Removed file '{u_file.name}' [file is empty].")
+            workspace.add_error(u_file, self.ZERO_LENGTH,
+                                self.ZERO_LENGTH_MESSAGE % u_file.name,
+                                severity=Severity.INFO, is_persistant=False)
+            workspace.remove(u_file, self.ZERO_LENGTH_MESSAGE % u_file.name)
         return u_file

--- a/filemanager/process/util/unmacify.py
+++ b/filemanager/process/util/unmacify.py
@@ -2,7 +2,7 @@ import mmap
 import re
 from arxiv.base import logging
 
-from ...domain import UserFile, Workspace
+from ...domain import UserFile, Workspace, Code
 
 logger = logging.getLogger(__name__)
 
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 # File types unmacify is interested in
 PC = 'pc'
 MAC = 'mac'
+
+UNMACIFIED: Code = 'unmacified'
+TRUNCATED: Code = 'truncated'
 
 
 def unmacify(workspace: Workspace, uploaded_file: UserFile) \
@@ -123,7 +126,7 @@ def check_file_termination(workspace: Workspace,
             if input_bytes[1] == 0x0A:
                 workspace.log.info(f"{u_file.path} [stripped newline] ")
 
-            workspace.add_warning(u_file,
+            workspace.add_warning(u_file, UNMACIFIED,
                                   f"{msg} stripped from {u_file.path}.",
                                   is_persistant=False)
 
@@ -132,6 +135,6 @@ def check_file_termination(workspace: Workspace,
         f.seek(-1, 2)
         last_byte = f.read(1)
         if last_byte != b'\n':
-            workspace.add_warning(u_file,
+            workspace.add_warning(u_file, TRUNCATED,
                                   f"File '{u_file.path}' does not end with"
                                   " newline (\\n), TRUNCATED?")

--- a/filemanager/services/database/__init__.py
+++ b/filemanager/services/database/__init__.py
@@ -164,7 +164,7 @@ def retrieve(upload_id: int, skip_cache: bool = False) -> Workspace:
         )
     if upload_data.errors:
         for datum in upload_data.errors:
-            workspace._errors.append(Error.from_dict(datum))
+            workspace._insert_error(Error.from_dict(datum))
     workspace.initialize()
     return workspace
 
@@ -261,7 +261,7 @@ def update(workspace: Workspace) -> None:
                     for p, f in workspace.files.removed.items()},
         'system': {p: f.to_dict() for p, f in workspace.files.system.items()},
     }
-    upload_data.errors = [e.to_dict() for e in workspace._errors
+    upload_data.errors = [e.to_dict() for e in workspace._errors.values()
                           if e.is_persistant]
 
     # 2019-06-28: In earlier versions, the ``modified_datetime`` of the

--- a/tests/test_api/test_eps_repair.py
+++ b/tests/test_api/test_eps_repair.py
@@ -98,7 +98,8 @@ class TestEPSRepair(TestCase):
         warnings = defaultdict(list)
         for _, name, msg in response_data['errors']:
             warnings[name].append(msg)
-        self.assertIn('leading TIFF preview stripped', warnings[fname])
+        self.assertIn('Leading TIFF preview stripped',
+                      ' '.join(warnings[fname]))
 
         # Now let's grab file content and verify that it matches expected
         # reference_path file.

--- a/tests/test_api/test_warnings_and_errors.py
+++ b/tests/test_api/test_warnings_and_errors.py
@@ -120,12 +120,11 @@ class TestUploadingPackageWithLotsOfWarningsAndErrors(TestCase):
             elif level == 'info':
                 info_errors[name].append(msg)
         files = {f['name']: f for f in self.response_data['files']}
-
         self.assertIn("Removed file 'remove.desc' [File not allowed].",
                       info_errors['remove.desc'])
         self.assertNotIn('remove.desc', files, 'File ware removed')
 
-        self.assertIn("Removed file '.junk' [File not allowed].",
+        self.assertIn("Hidden file are not allowed.",
                       info_errors['.junk'])
         self.assertNotIn('.junk', files, 'File was removed')
 
@@ -155,10 +154,7 @@ class TestUploadingPackageWithLotsOfWarningsAndErrors(TestCase):
 
         self.assertIn("We do not run bibtex in the auto",
                       ' '.join(warnings['final.bib']))
-        self.assertIn(
-            "Removed the file 'final.bib'. Using 'final.bbl' for references.",
-            info_errors['final.bib']
-        )
+
         self.assertNotIn('final.bib', files, 'File was removed')
 
         self.assertIn(
@@ -253,8 +249,8 @@ class TestUploadingPackageWithLotsOfWarningsAndErrors(TestCase):
                       "Please inspect and remove extraneous backup files.",
                       warnings['submission.tex_'])
 
-        self.assertIn("Renamed submission.tex~ to submission.tex_",
-                      warnings['submission.tex_'])
+        self.assertIn("Renamed 'submission.tex~' to 'submission.tex_'",
+                      ' '.join(warnings['submission.tex_']))
 
         # Another backup file
         self.assertIn("File 'submission.tex.bak' may be a backup file. "

--- a/tests/test_check_workspace.py
+++ b/tests/test_check_workspace.py
@@ -402,7 +402,7 @@ class TestBadFilenames(WorkspaceTestCase):
         self.write_upload('UploadTestWindowCDrive.tar.gz')
         self.workspace.perform_checks()
         self.assertTrue(self.workspace.has_warnings)
-        self.assertIn('Renamed c:\\data\\windows.txt to windows.txt',
+        self.assertIn('Renamed c:\\data\\windows.txt to windows.txt.',
                       self.workspace.get_warnings('windows.txt'))
 
     def test_contains_illegal_filenames(self):
@@ -411,7 +411,7 @@ class TestBadFilenames(WorkspaceTestCase):
         self.workspace.perform_checks()
         self.assertTrue(self.workspace.has_warnings)
         self.assertIn('Renamed 10-1-1(63).png to 10-1-1_63_.png',
-                      self.workspace.get_warnings('10-1-1_63_.png'))
+                      ' '.join(self.workspace.get_warnings('10-1-1_63_.png')))
 
 
 class TestUnpack(WorkspaceTestCase):

--- a/tests/test_check_workspace.py
+++ b/tests/test_check_workspace.py
@@ -304,8 +304,9 @@ class TestUploadScenarios(WorkspaceTestCase):
         self.write_upload('upload1.tar.gz')
         self.workspace.perform_checks()
         self.assertTrue(self.workspace.has_warnings)
-        self.assertIn("File 'espcrc2.sty' is empty (size is zero).",
-                      self.workspace.get_warnings('espcrc2.sty', is_removed=True))
+        self.assertIn("Removed file 'espcrc2.sty' [file is empty].",
+                      self.workspace.get_errors('espcrc2.sty',
+                                                is_removed=True))
 
     def test_well_formed_submission(self):
         """Upload is a well-formed submission package."""
@@ -323,9 +324,7 @@ class TestUploadScenarios(WorkspaceTestCase):
         """Upload is a well-formed submission package."""
         self.write_upload('upload4.gz')
         self.workspace.perform_checks()
-        self.assertTrue(self.workspace.has_warnings)
-        self.assertIn("Renamed 'upload4.gz' to 'upload4'.",
-                      self.workspace.get_warnings('upload4'))
+        self.assertFalse(self.workspace.has_warnings)
         self.assertTrue(self.workspace.has_errors_fatal)
 
     def test_yet_another_well_formed_submission(self):
@@ -358,7 +357,7 @@ class TestNestedArchives(WorkspaceTestCase):
         self.assertTrue(self.workspace.has_warnings)
         self.assertIn('There were problems unpacking \'jz2.zip\'. Please try'
                       ' again and confirm your files.',
-                      self.workspace.get_warnings('jz2.zip'))
+                      ' '.join(self.workspace.get_warnings('jz2.zip')))
 
     def test_contains_top_level_directory(self):
         """Contains a top-level directory."""
@@ -402,7 +401,7 @@ class TestBadFilenames(WorkspaceTestCase):
         self.write_upload('UploadTestWindowCDrive.tar.gz')
         self.workspace.perform_checks()
         self.assertTrue(self.workspace.has_warnings)
-        self.assertIn('Renamed c:\\data\\windows.txt to windows.txt.',
+        self.assertIn("Renamed 'c:\\data\\windows.txt' to 'windows.txt'.",
                       self.workspace.get_warnings('windows.txt'))
 
     def test_contains_illegal_filenames(self):
@@ -410,7 +409,7 @@ class TestBadFilenames(WorkspaceTestCase):
         self.write_upload('Upload9BadFileNames.tar.gz')
         self.workspace.perform_checks()
         self.assertTrue(self.workspace.has_warnings)
-        self.assertIn('Renamed 10-1-1(63).png to 10-1-1_63_.png',
+        self.assertIn("Renamed '10-1-1(63).png' to '10-1-1_63_.png'",
                       ' '.join(self.workspace.get_warnings('10-1-1_63_.png')))
 
 

--- a/tests/test_service_database.py
+++ b/tests/test_service_database.py
@@ -8,7 +8,7 @@ from pytz import UTC
 from typing import Any
 import sqlalchemy
 from filemanager.services import database
-from filemanager.domain import Workspace, Error, UserFile, Status
+from filemanager.domain import Workspace, Error, UserFile, Status, Severity
 from filemanager.services.storage import SimpleStorageAdapter
 
 
@@ -17,12 +17,12 @@ class TestTranslate(TestCase):
 
     def test_translate_error(self):
         """Translate an :class:`.Error` to and from a ``dict``."""
-        error = Error(severity=Error.Severity.FATAL, path='foo/path.md',
+        error = Error(severity=Severity.FATAL, path='foo/path.md',
                                message='This is a message',
                                is_persistant=True)
         self.assertEqual(error, Error.from_dict(error.to_dict()),
                          'Error is preserved with fidelity')
-        error = Error(severity=Error.Severity.FATAL, path='foo/path.md',
+        error = Error(severity=Severity.FATAL, path='foo/path.md',
                                message='This is a message',
                                is_persistant=False)
         self.assertEqual(error, Error.from_dict(error.to_dict()),
@@ -44,11 +44,11 @@ class TestTranslate(TestCase):
         u_file = UserFile(workspace=workspace,
                               path='foo/path.md', is_ancillary=True,
                               size_bytes=54_022, _errors=[
-                                  Error(severity=Error.Severity.FATAL,
+                                  Error(severity=Severity.FATAL,
                                         path='foo/path.md',
                                         message='This is a fatal error',
                                         is_persistant=True),
-                                  Error(severity=Error.Severity.WARNING,
+                                  Error(severity=Severity.WARNING,
                                         path='foo/path.md',
                                         message='This is a message',
                                         is_persistant=False),
@@ -57,7 +57,7 @@ class TestTranslate(TestCase):
         self.assertEqual(len(translated_file.errors), 1,
                          'Only one file is preserved')
         self.assertEqual(translated_file.errors[0].severity,
-                         Error.Severity.FATAL,
+                         Severity.FATAL,
                          'The persistant error is preserved')
 
 

--- a/tests/test_service_database.py
+++ b/tests/test_service_database.py
@@ -43,16 +43,18 @@ class TestTranslate(TestCase):
         workspace = mock.MagicMock(spec=Workspace)
         u_file = UserFile(workspace=workspace,
                               path='foo/path.md', is_ancillary=True,
-                              size_bytes=54_022, _errors=[
-                                  Error(severity=Severity.FATAL,
+                              size_bytes=54_022, _errors={
+                                  'fa_tal': Error(severity=Severity.FATAL,
                                         path='foo/path.md',
+                                        code='fa_tal',
                                         message='This is a fatal error',
                                         is_persistant=True),
-                                  Error(severity=Severity.WARNING,
+                                  'mes_sage': Error(severity=Severity.WARNING,
                                         path='foo/path.md',
+                                        code='mes_sage',
                                         message='This is a message',
                                         is_persistant=False),
-                              ])
+                              })
         translated_file = UserFile.from_dict(u_file.to_dict(), workspace)
         self.assertEqual(len(translated_file.errors), 1,
                          'Only one file is preserved')

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -4,7 +4,7 @@ import io
 from contextlib import contextmanager
 from unittest import TestCase, mock
 from datetime import datetime
-from filemanager.domain import UserFile, Workspace, Error, FileType
+from filemanager.domain import UserFile, Workspace, Error, FileType, Severity
 from filemanager.controllers.transform import transform_error, \
     transform_file, transform_workspace
 
@@ -14,14 +14,14 @@ class TestTransformError(TestCase):
 
     def test_transform_fatal_error(self):
         """Transform a fatal :class:`.Error."""
-        error = Error(severity=Error.Severity.FATAL, path='foo/path.md',
+        error = Error(severity=Severity.FATAL, path='foo/path.md',
                       message='This is a message', is_persistant=True)
         expected = ('fatal', 'foo/path.md', 'This is a message')
         self.assertEqual(transform_error(error), expected)
 
     def test_transform_warning_error(self):
         """Transform a warning :class:`.Error."""
-        error = Error(severity=Error.Severity.WARNING, path='foo/path.md',
+        error = Error(severity=Severity.WARNING, path='foo/path.md',
                       message='This is a message', is_persistant=True)
         expected = ('warn', 'foo/path.md', 'This is a message')
         self.assertEqual(transform_error(error), expected)
@@ -50,11 +50,11 @@ class TestTransformFile(TestCase):
                               path='foo/path.md', is_ancillary=False,
                               file_type=FileType.TEX,
                               size_bytes=54_022, _errors=[
-                                  Error(severity=Error.Severity.FATAL,
+                                  Error(severity=Severity.FATAL,
                                         path='foo/path.md',
                                         message='This is a fatal error',
                                         is_persistant=True),
-                                  Error(severity=Error.Severity.WARNING,
+                                  Error(severity=Severity.WARNING,
                                         path='foo/path.md',
                                         message='This is a message',
                                         is_persistant=False),

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -49,16 +49,19 @@ class TestTransformFile(TestCase):
         u_file = UserFile(workspace=workspace,
                               path='foo/path.md', is_ancillary=False,
                               file_type=FileType.TEX,
-                              size_bytes=54_022, _errors=[
-                                  Error(severity=Severity.FATAL,
+                              size_bytes=54_022,
+                              _errors={
+                                  'fatal_error': Error(severity=Severity.FATAL,
                                         path='foo/path.md',
+                                        code='fatal_error',
                                         message='This is a fatal error',
                                         is_persistant=True),
-                                  Error(severity=Severity.WARNING,
+                                  'message': Error(severity=Severity.WARNING,
                                         path='foo/path.md',
+                                        code='message',
                                         message='This is a message',
                                         is_persistant=False),
-                              ])
+                              })
         expected = {'name': 'path.md', 'public_filepath': 'foo/path.md',
                     'size': 54_022, 'type': 'TEX',
                     'modified_datetime': u_file.last_modified,
@@ -128,8 +131,8 @@ class TestTransformWorkspace(TestCase):
         workspace.initialize()
         u_file = workspace.create('foo/baz.md')
         u_file2 = workspace.create('secret', is_system=True)
-        workspace.add_error(u_file, 'foo error', is_persistant=True)
-        workspace.add_warning(u_file, 'foo warning', is_persistant=False)
+        workspace.add_error(u_file, 'foo_error', 'foo error', is_persistant=True)
+        workspace.add_warning(u_file, 'foo_warning', 'foo warning', is_persistant=False)
         transformd = transform_workspace(workspace)
         self.assertEqual(transformd['errors'],
                          [('fatal', 'foo/baz.md', 'foo error'),


### PR DESCRIPTION
This makes some fixes to handling of errors (and warnings):

- Errors are identified with a ``code`` -- a file may only have one error for a particular code, and a workspace may only have one non-file error for a particular code.
- Removing a file no longer automatically generates an error/warning. The caller must separately generate an error/warning. This gives a bit more flexibility, and better separation of concerns.
- Added support for removing errors.
- General cleanup/tidying of error-related methods and properties.