### PR TITLE
Workspace source format not cleared on "delete_all"

### DIFF
--- a/filemanager/domain/uploads/file_mutations.py
+++ b/filemanager/domain/uploads/file_mutations.py
@@ -15,6 +15,7 @@ from typing_extensions import Protocol
 
 from ..index import FileIndex
 
+from .source_type import SourceType
 from ..uploaded_file import UserFile
 from ..error import Error, Severity, Code
 from ..file_type import FileType
@@ -245,6 +246,7 @@ class FileMutations(IFileMutations):
         self.__api.files.ancillary.clear()
         self.__api.storage.makedirs(self, self.__api.source_path)
         self.__api.storage.makedirs(self, self.__api.ancillary_path)
+        self.__api.source_type = SourceType.UNKNOWN
 
     @modifies_workspace()
     def delete_workspace(self) -> bool:

--- a/tests/test_api/test_delete_all_files.py
+++ b/tests/test_api/test_delete_all_files.py
@@ -107,6 +107,8 @@ class TestDeleteAllFiles(TestCase):
 
         self.assertEqual(response.status_code, status.OK,
                          "Delete all user-uploaded files.")
+        self.assertNotEqual(json.loads(response.data)['source_format'], 'tex',
+                            'Source format should be cleared on a delete_all')
 
         response = self.client.get(f"/filemanager/api/{self.upload_id}",
                                    headers={'Authorization': self.token})


### PR DESCRIPTION
This bug appears to be a simple oversight to clear the source_type.